### PR TITLE
Add `end_of_episode_info` to `Obs`

### DIFF
--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -62,6 +62,12 @@ EntityID = Any
 
 
 @dataclass
+class EpisodeStats:
+    length: int
+    total_reward: float
+
+
+@dataclass
 class Observation:
     entities: Dict[str, np.ndarray]
     """Maps each entity type to an array with the features for each observed entity of that type."""
@@ -74,7 +80,7 @@ class Observation:
     """Maps each action to an action mask."""
     reward: float
     done: bool
-    info: Any = None
+    end_of_episode_info: Optional[EpisodeStats] = None
 
 
 @dataclass
@@ -167,7 +173,7 @@ class Environment(ABC):
             entity_name: entity_features[:, selectors[entity_name]]
             for entity_name, entity_features in obs.entities.items()
         }
-        return Observation(entities, obs.ids, obs.action_masks, obs.reward, obs.done)
+        return Observation(entities, obs.ids, obs.action_masks, obs.reward, obs.done, obs.end_of_episode_info)
 
     @classmethod
     def _compile_feature_filter(cls, obs_filter: ObsFilter) -> Dict[str, np.ndarray]:
@@ -236,6 +242,7 @@ class EnvList(VecEnv):
                 new_obs = e._reset()
                 new_obs.done = True
                 new_obs.reward = obs.reward
+                new_obs.end_of_episode_info = obs.end_of_episode_info
                 observations.append(new_obs)
             else:
                 observations.append(obs)

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -173,7 +173,14 @@ class Environment(ABC):
             entity_name: entity_features[:, selectors[entity_name]]
             for entity_name, entity_features in obs.entities.items()
         }
-        return Observation(entities, obs.ids, obs.action_masks, obs.reward, obs.done, obs.end_of_episode_info)
+        return Observation(
+            entities,
+            obs.ids,
+            obs.action_masks,
+            obs.reward,
+            obs.done,
+            obs.end_of_episode_info,
+        )
 
     @classmethod
     def _compile_feature_filter(cls, obs_filter: ObsFilter) -> Dict[str, np.ndarray]:

--- a/entity_gym/entity_gym/envs/move_to_origin.py
+++ b/entity_gym/entity_gym/envs/move_to_origin.py
@@ -133,7 +133,7 @@ class MoveToOrigin(Environment):
             done=done,
             end_of_episode_info=EpisodeStats(
                 length=self.step,
-                total_reward=1 - (self.x_pos ** 2 + self.y_pos ** 2) ** 0.5
+                total_reward=1 - (self.x_pos ** 2 + self.y_pos ** 2) ** 0.5,
             )
             if done
             else None,

--- a/entity_gym/entity_gym/envs/move_to_origin.py
+++ b/entity_gym/entity_gym/envs/move_to_origin.py
@@ -10,6 +10,7 @@ from entity_gym.environment import (
     Environment,
     CategoricalActionSpace,
     ActionSpace,
+    EpisodeStats,
     Observation,
     Action,
 )
@@ -130,4 +131,10 @@ class MoveToOrigin(Environment):
             reward=(self.last_x_pos ** 2 + self.last_y_pos ** 2) ** 0.5
             - (self.x_pos ** 2 + self.y_pos ** 2) ** 0.5,
             done=done,
+            end_of_episode_info=EpisodeStats(
+                length=self.step,
+                total_reward=1 - (self.x_pos ** 2 + self.y_pos ** 2) ** 0.5
+            )
+            if done
+            else None,
         )

--- a/entity_gym/entity_gym/envs/multi_armed_bandit.py
+++ b/entity_gym/entity_gym/envs/multi_armed_bandit.py
@@ -10,6 +10,7 @@ from entity_gym.environment import (
     Environment,
     CategoricalActionSpace,
     ActionSpace,
+    EpisodeStats,
     Observation,
     Action,
 )
@@ -35,6 +36,7 @@ class MultiArmedBandit(Environment):
 
     def _reset(self) -> Observation:
         self.step = 0
+        self._total_reward = 0
         return self.observe()
 
     def _act(self, action: Mapping[str, Action]) -> Observation:
@@ -47,6 +49,7 @@ class MultiArmedBandit(Environment):
         else:
             reward = 0
         done = self.step >= 32
+        self._total_reward += reward
         return self.observe(done, reward)
 
     def observe(self, done: bool = False, reward: float = 0) -> Observation:
@@ -58,4 +61,5 @@ class MultiArmedBandit(Environment):
             ids=[0],
             reward=reward,
             done=done,
+            end_of_episode_info=EpisodeStats(self.step, self._total_reward) if done else None,
         )

--- a/entity_gym/entity_gym/envs/multi_armed_bandit.py
+++ b/entity_gym/entity_gym/envs/multi_armed_bandit.py
@@ -61,5 +61,7 @@ class MultiArmedBandit(Environment):
             ids=[0],
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, self._total_reward) if done else None,
+            end_of_episode_info=EpisodeStats(self.step, self._total_reward)
+            if done
+            else None,
         )

--- a/ppo/train.py
+++ b/ppo/train.py
@@ -361,18 +361,22 @@ def train(args: argparse.Namespace) -> float:
             )
             next_done = torch.tensor([o.done for o in next_obs]).to(device).view(-1)
 
-            # for item in info:
-            #    if "episode" in item.keys():
-            #        print(
-            #            f"global_step={global_step}, episodic_return={item['episode']['r']}"
-            #        )
-            #        writer.add_scalar(
-            #            "charts/episodic_return", item["episode"]["r"], global_step
-            #        )
-            #        writer.add_scalar(
-            #            "charts/episodic_length", item["episode"]["l"], global_step
-            #        )
-            #        break
+            for o in next_obs:
+                if o.end_of_episode_info is not None:
+                    print(
+                        f"global_step={global_step}, episodic_return={o.end_of_episode_info.total_reward}"
+                    )
+                    writer.add_scalar(
+                        "charts/episodic_return",
+                        o.end_of_episode_info.total_reward,
+                        global_step,
+                    )
+                    writer.add_scalar(
+                        "charts/episodic_length",
+                        o.end_of_episode_info.length,
+                        global_step,
+                    )
+                    break
 
         # bootstrap value if not done
         with torch.no_grad():


### PR DESCRIPTION
Replace the untyped `info` field of `Obs` with a typed `end_of_episode_info` struct.
Also reenable logging of total episode reward and length in PPO: https://wandb.ai/cswinter/enn-ppo/runs/3idlrvsk