### PR TITLE
Layer initialization fix

### DIFF
--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -10,7 +10,7 @@ def layer_init(
     layer: nn.Module, std: float = np.sqrt(2), bias_const: float = 0.0,
 ) -> nn.Module:
     torch.nn.init.orthogonal_(layer.weight, std)
-    torch.nn.init.constant_(layer.bias, bias_const) # type: ignore
+    torch.nn.init.constant_(layer.bias, bias_const)  # type: ignore
     return layer
 
 

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -3,12 +3,12 @@ from torch import nn
 import torch
 import numpy as np
 from entity_gym.environment import ActionSpace, CategoricalActionSpace
-from typing import Dict
+from typing import Dict, Union
 
 
 def layer_init(
-    layer: nn.Module, std: float = np.sqrt(2), bias_const: float = 0.0
-) -> nn.Module:
+    layer: Union[torch.Tensor, nn.Module], std: float = np.sqrt(2), bias_const: float = 0.0
+) -> Union[torch.Tensor, nn.Module]:
     torch.nn.init.orthogonal_(layer.weight, std)
     torch.nn.init.constant_(layer.bias, bias_const)
     return layer

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -3,16 +3,14 @@ from torch import nn
 import torch
 import numpy as np
 from entity_gym.environment import ActionSpace, CategoricalActionSpace
-from typing import Dict, Union
+from typing import Dict
 
 
 def layer_init(
-    layer: Union[torch.Tensor, nn.Module],
-    std: float = np.sqrt(2),
-    bias_const: float = 0.0,
-) -> Union[torch.Tensor, nn.Module]:
+    layer: nn.Module, std: float = np.sqrt(2), bias_const: float = 0.0,
+) -> nn.Module:
     torch.nn.init.orthogonal_(layer.weight, std)
-    torch.nn.init.constant_(layer.bias, bias_const)
+    torch.nn.init.constant_(layer.bias, bias_const) # type: ignore
     return layer
 
 

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -3,13 +3,12 @@ from torch import nn
 import torch
 import numpy as np
 from entity_gym.environment import ActionSpace, CategoricalActionSpace
-from typing import (
-    Any,
-    Dict,
-)
+from typing import Dict
 
 
-def layer_init(layer: Any, std: float = np.sqrt(2), bias_const: float = 0.0) -> Any:
+def layer_init(
+    layer: nn.Module, std: float = np.sqrt(2), bias_const: float = 0.0
+) -> nn.Module:
     torch.nn.init.orthogonal_(layer.weight, std)
     torch.nn.init.constant_(layer.bias, bias_const)
     return layer

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -1,19 +1,28 @@
 from typing import Dict
 from torch import nn
-
+import torch
+import numpy as np
 from entity_gym.environment import ActionSpace, CategoricalActionSpace
+from typing import (
+    Any,
+    Dict,
+)
+
+
+def layer_init(layer: Any, std: float = np.sqrt(2), bias_const: float = 0.0) -> Any:
+    torch.nn.init.orthogonal_(layer.weight, std)
+    torch.nn.init.constant_(layer.bias, bias_const)
+    return layer
 
 
 def create_head_for(space: ActionSpace, d_model: int) -> nn.Module:
     if isinstance(space, CategoricalActionSpace):
-        return nn.Linear(d_model, len(space.choices))
+        return layer_init(nn.Linear(d_model, len(space.choices)), std=0.01)
     raise NotImplementedError()
 
 
 def create_value_head(d_model: int) -> nn.Module:
-    value_head = nn.Linear(d_model, 1)
-    value_head.weight.data.fill_(0.0)
-    value_head.bias.data.fill_(0.0)
+    value_head = layer_init(nn.Linear(d_model, 1), std=1.0)
     return value_head
 
 

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -7,7 +7,9 @@ from typing import Dict, Union
 
 
 def layer_init(
-    layer: Union[torch.Tensor, nn.Module], std: float = np.sqrt(2), bias_const: float = 0.0
+    layer: Union[torch.Tensor, nn.Module],
+    std: float = np.sqrt(2),
+    bias_const: float = 0.0,
 ) -> Union[torch.Tensor, nn.Module]:
     torch.nn.init.orthogonal_(layer.weight, std)
     torch.nn.init.constant_(layer.bias, bias_const)


### PR DESCRIPTION
This PR initializes the policy and value heads the same way openai/baselines' PPO does it. Specifically, the actor's heads are initialized with `std=0.01` and value's head `std=1.0` ([baselines/common/policies.py#L49-L63](https://github.com/openai/baselines/blob/ea25b9e8b234e6ee1bca43083f8f3cf974143998/baselines/common/policies.py#L49-L63)). 