### PR TITLE
Implement SelectEntity action head

### DIFF
--- a/enn_ppo/enn_ppo/test_training.py
+++ b/enn_ppo/enn_ppo/test_training.py
@@ -10,7 +10,7 @@ def test_multi_armed_bandit() -> None:
             "--num-steps=16",
             "--gamma=0.5",
             "--cuda=False",
-            "--hidden-size=16",
+            "--d-model=16",
             "--learning-rate=0.05",
             "--n-layer=0",
         ]
@@ -27,7 +27,7 @@ def test_minefield() -> None:
             "--total-timesteps=256",
             "--num-steps=16",
             "--cuda=False",
-            "--hidden-size=16",
+            "--d-model=16",
         ]
     )
     meanrew = train.train(args)
@@ -42,7 +42,7 @@ def test_multi_snake() -> None:
             "--total-timesteps=256",
             "--num-steps=16",
             "--cuda=False",
-            "--hidden-size=16",
+            "--d-model=16",
         ]
     )
     meanrew = train.train(args)
@@ -51,7 +51,7 @@ def test_multi_snake() -> None:
 
 
 def test_not_hotdog() -> None:
-    # --total-timesteps=500 --ent-coef=0 --gym-id=NotHotdog --num-steps=16 --gamma=0.5 --cuda=False --hidden-size=16 --learning-rate=0.05
+    # --total-timesteps=500 --ent-coef=0 --gym-id=NotHotdog --num-steps=16 --gamma=0.5 --cuda=False --d-model=16 --learning-rate=0.05
     args = train.parse_args(
         [
             "--total-timesteps=500",
@@ -61,7 +61,7 @@ def test_not_hotdog() -> None:
             "--gamma=0.5",
             "--cuda=False",
             "--n-layer=1",
-            "--hidden-size=16",
+            "--d-model=16",
             "--learning-rate=0.005",
         ]
     )
@@ -71,7 +71,7 @@ def test_not_hotdog() -> None:
 
 
 def test_count() -> None:
-    # --total-timesteps=2000 --track --gym-id=Count --num-envs=16 --max-log-frequency=1000 --n-layer=1 --num-steps=1 --hidden-size=16 --learning-rate=0.01 --cuda=False
+    # --total-timesteps=2000 --track --gym-id=Count --num-envs=16 --max-log-frequency=1000 --n-layer=1 --num-steps=1 --d-model=16 --learning-rate=0.01 --cuda=False
     args = train.parse_args(
         [
             "--total-timesteps=2000",
@@ -79,7 +79,7 @@ def test_count() -> None:
             "--num-envs=16",
             "--n-layer=1",
             "--num-steps=1",
-            "--hidden-size=16",
+            "--d-model=16",
             "--learning-rate=0.01",
             "--cuda=False",
         ]
@@ -96,7 +96,7 @@ def test_pick_matching_balls() -> None:
             "--total-timesteps=256",
             "--num-steps=16",
             "--cuda=False",
-            "--hidden-size=16",
+            "--d-model=16",
         ]
     )
     meanrew = train.train(args)
@@ -111,7 +111,7 @@ def test_cherry_pick() -> None:
             "--total-timesteps=256",
             "--num-steps=16",
             "--cuda=False",
-            "--hidden-size=16",
+            "--d-model=16",
         ]
     )
     meanrew = train.train(args)

--- a/enn_ppo/enn_ppo/test_training.py
+++ b/enn_ppo/enn_ppo/test_training.py
@@ -87,3 +87,32 @@ def test_count() -> None:
     meanrw = train.train(args)
     print(f"Final mean reward: {meanrw}")
     assert meanrw >= 0.99
+
+
+def test_pick_matching_balls() -> None:
+    args = train.parse_args(
+        [
+            "--gym-id=PickMatchingBalls",
+            "--total-timesteps=256",
+            "--num-steps=16",
+            "--cuda=False",
+            "--hidden-size=16",
+        ]
+    )
+    meanrew = train.train(args)
+    print(f"Final mean reward: {meanrew}")
+    assert meanrew >= 0.0
+
+
+def test_cherry_pick() -> None:
+    args = train.parse_args(
+        [
+            "--gym-id=CherryPick",
+            "--total-timesteps=256",
+            "--num-steps=16",
+            "--cuda=False",
+            "--hidden-size=16",
+        ]
+    )
+    meanrew = train.train(args)
+    print(f"Final mean reward: {meanrew}")

--- a/enn_ppo/pyproject.toml
+++ b/enn_ppo/pyproject.toml
@@ -13,7 +13,7 @@ msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 tqdm = "^4.62.3"
 torch-scatter = "^2.0.9"
-ragged-buffer = "^0.2.8"
+ragged-buffer = "^0.2.10"
 wandb = "^0.12.7"
 enn_zoo = {path = "../enn_zoo", develop=true}
 entity_gym = {path = "../entity_gym", develop = true}

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -65,7 +65,7 @@ class DenseSelectEntityActionMask(ActionMask):
     """
 
     actees: npt.NDArray[np.int64]
-    mask: Optional[np.ndarray]
+    mask: Optional[np.ndarray] = None
     """
     An boolean array of shape (len(actors), len(entities)). If mask[i, j] is True, then
     agent i can select entity j.

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -166,8 +166,6 @@ class SelectEntityActionMaskBatch:
         ), f"Expected SelectEntityActionMaskBatch, got {type(other)}"
         self.actors.extend(other.actors)
         self.actees.extend(other.actees)
-        self.actors.extend(other.actors)
-        self.actees.extend(other.actees)
 
     def clear(self) -> None:
         self.actors.clear()

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -1,6 +1,17 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 import numpy as np
 import numpy.typing as npt
 from ragged_buffer import RaggedBufferF32, RaggedBufferI64
@@ -53,6 +64,7 @@ class DenseSelectEntityActionMask(ActionMask):
     each actor.
     """
 
+    actees: npt.NDArray[np.int64]
     mask: Optional[np.ndarray]
     """
     An boolean array of shape (len(actors), len(entities)). If mask[i, j] is True, then
@@ -87,11 +99,89 @@ class Observation:
 
 
 @dataclass
+class CategoricalActionMaskBatch:
+    actors: RaggedBufferI64
+
+    def push(self, mask: Any) -> None:
+        assert isinstance(mask, DenseCategoricalActionMask)
+        self.actors.push(mask.actors.reshape(-1, 1))
+
+    @overload
+    def __getitem__(self, i: int) -> RaggedBufferI64:
+        ...
+
+    @overload
+    def __getitem__(self, i: npt.NDArray[np.int64]) -> "CategoricalActionMaskBatch":
+        ...
+
+    def __getitem__(
+        self, i: Union[int, npt.NDArray[np.int64]]
+    ) -> Union["CategoricalActionMaskBatch", RaggedBufferI64]:
+        if isinstance(i, int):
+            return self.actors[i]
+        else:
+            return CategoricalActionMaskBatch(self.actors[i])
+
+    def extend(self, other: Any) -> None:
+        assert isinstance(
+            other, CategoricalActionMaskBatch
+        ), f"Expected CategoricalActionMaskBatch, got {type(other)}"
+        self.actors.extend(other.actors)
+
+    def clear(self) -> None:
+        self.actors.clear()
+
+
+@dataclass
+class SelectEntityActionMaskBatch:
+    actors: RaggedBufferI64
+    actees: RaggedBufferI64
+
+    def push(self, mask: Any) -> None:
+        assert isinstance(
+            mask, DenseSelectEntityActionMask
+        ), f"Expected DenseSelectEntityActionMask, got {type(mask)}"
+        self.actors.push(mask.actors.reshape(-1, 1))
+        self.actees.push(mask.actees.reshape(-1, 1))
+
+    @overload
+    def __getitem__(self, i: int) -> RaggedBufferI64:
+        ...
+
+    @overload
+    def __getitem__(self, i: npt.NDArray[np.int64]) -> "SelectEntityActionMaskBatch":
+        ...
+
+    def __getitem__(
+        self, i: Union[int, npt.NDArray[np.int64]]
+    ) -> Union["SelectEntityActionMaskBatch", RaggedBufferI64]:
+        if isinstance(i, int):
+            return self.actors[i]
+        else:
+            return SelectEntityActionMaskBatch(self.actors[i], self.actees[i])
+
+    def extend(self, other: Any) -> None:
+        assert isinstance(
+            other, SelectEntityActionMaskBatch
+        ), f"Expected SelectEntityActionMaskBatch, got {type(other)}"
+        self.actors.extend(other.actors)
+        self.actees.extend(other.actees)
+        self.actors.extend(other.actors)
+        self.actees.extend(other.actees)
+
+    def clear(self) -> None:
+        self.actors.clear()
+        self.actees.clear()
+
+
+ActionMaskBatch = Union[CategoricalActionMaskBatch, SelectEntityActionMaskBatch]
+
+
+@dataclass
 class ObsBatch:
     entities: Dict[str, RaggedBufferF32]
     ids: Sequence[Sequence[EntityID]]
-    # TODO: currently assumes categorical actions and no mask
-    action_masks: Mapping[str, RaggedBufferI64]
+    action_masks: Mapping[str, ActionMaskBatch]
     reward: npt.NDArray[np.float32]
     done: npt.NDArray[np.bool_]
     end_of_episode_info: Dict[int, EpisodeStats]
@@ -103,7 +193,9 @@ def batch_obs(obs: List[Observation]) -> ObsBatch:
     """
     entities = {}
     ids = []
-    action_masks = {}
+    action_masks: Dict[
+        str, Union[CategoricalActionMaskBatch, SelectEntityActionMaskBatch]
+    ] = {}
     reward = []
     done = []
     end_of_episode_info = {}
@@ -114,10 +206,16 @@ def batch_obs(obs: List[Observation]) -> ObsBatch:
             entities[k].push(feats)
         ids.append(o.ids)
         for k, mask in o.action_masks.items():
-            assert isinstance(mask, DenseCategoricalActionMask)
-            if k not in action_masks:
-                action_masks[k] = RaggedBufferI64(1)
-            action_masks[k].push(mask.actors.reshape(-1, 1))
+            if isinstance(mask, DenseCategoricalActionMask):
+                if k not in action_masks:
+                    action_masks[k] = CategoricalActionMaskBatch(RaggedBufferI64(1))
+            elif isinstance(mask, DenseSelectEntityActionMask):
+                if k not in action_masks:
+                    action_masks[k] = SelectEntityActionMaskBatch(
+                        RaggedBufferI64(1), RaggedBufferI64(1)
+                    )
+            action_masks[k].push(mask)
+
         reward.append(o.reward)
         done.append(o.done)
         if o.end_of_episode_info:

--- a/entity_gym/entity_gym/envs/cherry_pick.py
+++ b/entity_gym/entity_gym/envs/cherry_pick.py
@@ -55,13 +55,14 @@ class CherryPick(Environment):
     def observe(self) -> Observation:
         return Observation(
             entities={
-                "Cherry": np.array(self.cherries).reshape(-1, 1),
-                "Player": np.zeros([1, 0]),
+                "Cherry": np.array(self.cherries, dtype=np.float32).reshape(-1, 1),
+                "Player": np.zeros([1, 0], dtype=np.float32),
             },
             ids=np.arange(len(self.cherries) + 1),
             action_masks={
                 "Pick Cherry": DenseSelectEntityActionMask(
                     actors=np.array([len(self.cherries)]),
+                    actees=np.arange(1, len(self.cherries) + 1),
                     mask=(
                         np.arange(len(self.cherries) + 1) < len(self.cherries)
                     ).astype(np.float32),

--- a/entity_gym/entity_gym/envs/cherry_pick.py
+++ b/entity_gym/entity_gym/envs/cherry_pick.py
@@ -26,6 +26,7 @@ class CherryPick(Environment):
     The quality of the top 16 cherries is normalized so that the maximum total achievable reward is 1.0.
     """
 
+    num_cherries: int = 32
     cherries: List[float] = field(default_factory=list)
     last_reward: float = 0.0
     step: int = 0
@@ -44,18 +45,19 @@ class CherryPick(Environment):
         return {"Pick Cherry": SelectEntityActionSpace()}
 
     def _reset(self) -> Observation:
-        cherries = [np.random.normal() for _ in range(32)]
-        # Normalize so that the sum of the top 16 is 1.0
-        top_16 = sorted(cherries, reverse=True)[:16]
-        sum_top_16 = sum(top_16)
-        normalized_cherries = [c / sum_top_16 for c in cherries]
-        self.cherries = normalized_cherries
+        cherries = [np.random.normal() for _ in range(self.num_cherries)]
+        # Normalize so that the sum of the top half is 1.0
+        top_half = sorted(cherries, reverse=True)[: self.num_cherries // 2]
+        sum_top_half = sum(top_half)
+        add = 2.0 * (1.0 - sum_top_half) / self.num_cherries
+        self.cherries = [c + add for c in cherries]
         self.last_reward = 0.0
         self.step = 0
         self.total_reward = 0.0
         return self.observe()
 
     def observe(self) -> Observation:
+        done = self.step == self.num_cherries // 2
         return Observation(
             entities={
                 "Cherry": np.array(self.cherries, dtype=np.float32).reshape(-1, 1),
@@ -65,22 +67,24 @@ class CherryPick(Environment):
             action_masks={
                 "Pick Cherry": DenseSelectEntityActionMask(
                     actors=np.array([len(self.cherries)]),
-                    actees=np.arange(1, len(self.cherries) + 1),
+                    actees=np.arange(len(self.cherries)),
                     mask=(
                         np.arange(len(self.cherries) + 1) < len(self.cherries)
                     ).astype(np.float32),
                 ),
             },
             reward=self.last_reward,
-            done=self.step == 16,
-            end_of_episode_info=EpisodeStats(16, self.total_reward),
+            done=done,
+            end_of_episode_info=EpisodeStats(self.step, self.total_reward)
+            if done
+            else None,
         )
 
     def _act(self, action: Mapping[str, Action]) -> Observation:
-        for action_name, a in action.items():
-            assert isinstance(a, SelectEntityAction)
-            assert action_name == "Pick Cherry"
-            self.last_reward = self.cherries.pop(a.actions[0][1])
-            self.total_reward += self.last_reward
+        assert len(action) == 1
+        a = action["Pick Cherry"]
+        assert isinstance(a, SelectEntityAction)
+        self.last_reward = self.cherries.pop(a.actions[0][1])
+        self.total_reward += self.last_reward
         self.step += 1
         return self.observe()

--- a/entity_gym/entity_gym/envs/cherry_pick.py
+++ b/entity_gym/entity_gym/envs/cherry_pick.py
@@ -6,6 +6,7 @@ from entity_gym.environment import (
     DenseSelectEntityActionMask,
     Entity,
     Environment,
+    EpisodeStats,
     ObsSpace,
     SelectEntityAction,
     SelectEntityActionSpace,
@@ -50,6 +51,8 @@ class CherryPick(Environment):
         normalized_cherries = [c / sum_top_16 for c in cherries]
         self.cherries = normalized_cherries
         self.last_reward = 0.0
+        self.step = 0
+        self.total_reward = 0.0
         return self.observe()
 
     def observe(self) -> Observation:
@@ -70,6 +73,7 @@ class CherryPick(Environment):
             },
             reward=self.last_reward,
             done=self.step == 16,
+            end_of_episode_info=EpisodeStats(16, self.total_reward),
         )
 
     def _act(self, action: Mapping[str, Action]) -> Observation:
@@ -77,5 +81,6 @@ class CherryPick(Environment):
             assert isinstance(a, SelectEntityAction)
             assert action_name == "Pick Cherry"
             self.last_reward = self.cherries.pop(a.actions[0][1])
+            self.total_reward += self.last_reward
         self.step += 1
         return self.observe()

--- a/entity_gym/pyproject.toml
+++ b/entity_gym/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-ragged-buffer = "^0.2.8"
+ragged-buffer = "^0.2.10"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,7 +49,7 @@ python-versions = "*"
 
 [[package]]
 name = "black"
-version = "21.11b1"
+version = "21.12b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -60,7 +60,6 @@ click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
-regex = ">=2021.4.4"
 tomli = ">=0.2.6,<2.0.0"
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = ">=3.10.0.0"
@@ -173,7 +172,7 @@ entity_gym = {path = "../entity_gym", develop = true}
 msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 numpy = "^1.21.4"
-ragged-buffer = "^0.2.8"
+ragged-buffer = "^0.2.10"
 rogue_net = {path = "../rogue_net", develop = true}
 tensorboard = "^2.7.0"
 torch = "^1.10.0"
@@ -211,7 +210,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-ragged-buffer = "^0.2.8"
+ragged-buffer = "^0.2.10"
 
 [package.source]
 type = "directory"
@@ -337,7 +336,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imageio"
-version = "2.13.1"
+version = "2.13.2"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
 optional = false
@@ -771,7 +770,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "ragged-buffer"
-version = "0.2.8"
+version = "0.2.10"
 description = ""
 category = "main"
 optional = false
@@ -779,14 +778,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 numpy = ">=1.21,<2.0"
-
-[[package]]
-name = "regex"
-version = "2021.11.10"
-description = "Alternative regular expression module, to replace re."
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "requests"
@@ -831,7 +822,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-ragged-buffer = "^0.2.8"
+ragged-buffer = "^0.2.10"
 torch = "^1.10.0"
 torch-scatter = "^2.0.9"
 
@@ -1154,8 +1145,8 @@ backcall = [
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
 black = [
-    {file = "black-21.11b1-py3-none-any.whl", hash = "sha256:802c6c30b637b28645b7fde282ed2569c0cd777dbe493a41b6a03c1d903f99ac"},
-    {file = "black-21.11b1.tar.gz", hash = "sha256:a042adbb18b3262faad5aff4e834ff186bb893f95ba3a8013f09de1e5569def2"},
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 cachetools = [
     {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},
@@ -1280,8 +1271,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imageio = [
-    {file = "imageio-2.13.1-py3-none-any.whl", hash = "sha256:2b45f8275bf3f513f80512da540d60268417021d217cac7c384783be0acb42fe"},
-    {file = "imageio-2.13.1.tar.gz", hash = "sha256:d3672d6a676f284c13a89d632b07b441f234caf0748e59271a18464a84172040"},
+    {file = "imageio-2.13.2-py3-none-any.whl", hash = "sha256:4acc2a2d0210170ee109c59edc178cee818c87f0a33a2a35116a19e3ac7badc0"},
+    {file = "imageio-2.13.2.tar.gz", hash = "sha256:5b7a55d07de88a2fd70f18a1608ca05ba2b55596a942fb2c390240201009a6c3"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
@@ -1642,84 +1633,12 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 ragged-buffer = [
-    {file = "ragged_buffer-0.2.8-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:b0a122afaf202e815284d267df2239cdd5b9beefabce516266103f97ed91a08f"},
-    {file = "ragged_buffer-0.2.8.tar.gz", hash = "sha256:c667bf0d51868b1a9cce75166e645d9672ca300c721330ad363cbfc48774aa07"},
-]
-regex = [
-    {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},
-    {file = "regex-2021.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b"},
-    {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
-    {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
-    {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00"},
-    {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
-    {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
-    {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a"},
-    {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
-    {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
-    {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
-    {file = "regex-2021.11.10-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0"},
-    {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
-    {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
-    {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
-    {file = "regex-2021.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d"},
-    {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
-    {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
-    {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
+    {file = "ragged_buffer-0.2.10-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:cab38efd4c5edba23626a3a38595607bfd82e85ce7556df73826d970558f46c0"},
+    {file = "ragged_buffer-0.2.10-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:ce5e07335bb133ddd8b6c7f60bd8eff5737e91ce58da31e9bd4b2ddca6bfa027"},
+    {file = "ragged_buffer-0.2.10-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:93484877250abdd8d8c496e2b4b840a8d531390ed451cd512407ebb4aa8df8ce"},
+    {file = "ragged_buffer-0.2.10-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:bbc074ec1fee2a1cc0b6c8c8b351152e11e17cc1b0e6f6218d4af10bcebf04d2"},
+    {file = "ragged_buffer-0.2.10-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:b3e3b5b1cf8979693ce72741fcd7756df1a276adab0c6b71583e88512af71abe"},
+    {file = "ragged_buffer-0.2.10.tar.gz", hash = "sha256:699c6ce8c76f9e7153c394ad16855042c58fed6f082194110147c80cac0abbb4"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},

--- a/rogue_net/pyproject.toml
+++ b/rogue_net/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 python = ">=3.7.1,<3.10"
 torch = "^1.10.0"
 torch-scatter = "^2.0.9"
-ragged-buffer = "^0.2.8"
+ragged-buffer = "^0.2.10"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/rogue_net/rogue_net/actor.py
+++ b/rogue_net/rogue_net/actor.py
@@ -1,15 +1,16 @@
 from typing import Dict, List, Mapping, Optional, Tuple, Type, TypeVar
 
 from entity_gym.environment import (
+    ActionMaskBatch,
     ActionSpace,
     ObsSpace,
 )
 from enn_ppo.simple_trace import Tracer
 import numpy as np
 import ragged_buffer
+from rogue_net.ragged_tensor import RaggedTensor
 import torch
 import torch.nn as nn
-from torch.distributions.categorical import Categorical
 import torch_scatter
 import numpy.typing as npt
 
@@ -55,25 +56,7 @@ class Actor(nn.Module):
 
     def batch_and_embed(
         self, entities: Mapping[str, RaggedBufferF32], tracer: Tracer
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Example:
-        entities in obs 0: [A0, A0, A0, B0]
-        entities in obs 1: [A1, B1, B1]
-        entities in obs 2: [A2, A2]
-
-        `x` is a flattened tensor of entity embeddings sorted first by entity type, then by batch index:
-        [A0, A0, A0, A1, A2, A2, B0, B1, B1]
-
-        `index_map` translates the index of entities sorted first by batch index then by entity type to their index in `x`:
-        [0, 1, 2, 6, 3, 7, 8, 4, 5]
-
-        `batch_index` gives the batch index of each entity in `x`:
-        [0, 0, 0, 1, 2, 2, 0, 1, 1]
-
-        `lengths` gives the number of entities in each observation:
-        [4, 3, 2]
-        """
+    ) -> RaggedTensor:
         entity_embeds = []
         index_offsets = {}
         index_offset = 0
@@ -109,7 +92,7 @@ class Actor(nn.Module):
         with tracer.span("backbone"):
             x = self.backbone(x, tbatch_index)
 
-        return (
+        return RaggedTensor(
             x,
             tindex_map,
             tbatch_index,
@@ -119,16 +102,16 @@ class Actor(nn.Module):
     def get_auxiliary_head(
         self, entities: Mapping[str, RaggedBufferF32], head_name: str, tracer: Tracer
     ) -> torch.Tensor:
-        embeddings, _, batch_index, _ = self.batch_and_embed(entities, tracer)
+        x = self.batch_and_embed(entities, tracer)
         pooled = torch_scatter.scatter(
-            src=embeddings, dim=0, index=batch_index, reduce="mean"
+            src=x.data, dim=0, index=x.batch_index, reduce="mean"
         )
         return self.auxiliary_heads[head_name](pooled)  # type: ignore
 
     def get_action_and_auxiliary(
         self,
         entities: Mapping[str, RaggedBufferF32],
-        action_masks: Mapping[str, RaggedBufferI64],
+        action_masks: Mapping[str, ActionMaskBatch],
         tracer: Tracer,
         prev_actions: Optional[Dict[str, RaggedBufferI64]] = None,
     ) -> Tuple[
@@ -142,11 +125,11 @@ class Actor(nn.Module):
         probs: Dict[str, torch.Tensor] = {}
         entropies: Dict[str, torch.Tensor] = {}
         with tracer.span("batch_and_embed"):
-            x, index_map, batch_index, lengths = self.batch_and_embed(entities, tracer)
+            x = self.batch_and_embed(entities, tracer)
 
         tracer.start("action_heads")
         index_offsets = RaggedBufferI64.from_array(
-            torch.cat([torch.tensor([0]).to(self.device()), lengths[:-1]])
+            torch.cat([torch.tensor([0]).to(self.device()), x.lengths[:-1]])
             .cumsum(0)
             .cpu()
             .numpy()
@@ -154,33 +137,22 @@ class Actor(nn.Module):
         )
         actor_counts: Dict[str, np.ndarray] = {}
         for action_name, action_head in self.action_heads.items():
-            actor_counts[action_name] = np.array(
-                [
-                    action_masks[action_name].size1(i)
-                    for i in range(action_masks[action_name].size0())
-                ]
+            action, count, logprob, entropy = action_head(
+                x,
+                index_offsets,
+                action_masks[action_name],
+                prev_actions[action_name] if prev_actions is not None else None,
             )
-            actors = torch.tensor(
-                (action_masks[action_name] + index_offsets).as_array()
-            ).to(self.device())
-            actor_embeds = x[index_map[actors]]
-            logits = action_head(actor_embeds)
-            dist = Categorical(logits=logits)
-            if prev_actions is None:
-                action = dist.sample()
-            else:
-                action = torch.tensor(prev_actions[action_name].as_array()).to(
-                    self.device()
-                )
+            actor_counts[action_name] = count
             actions[action_name] = action
-            probs[action_name] = dist.log_prob(action)
-            entropies[action_name] = dist.entropy()
+            probs[action_name] = logprob
+            entropies[action_name] = entropy
         tracer.end("action_heads")
 
         tracer.start("auxiliary_heads")
         if self.auxiliary_heads:
             pooled = torch_scatter.scatter(
-                src=x, dim=0, index=batch_index, reduce="mean"
+                src=x.data, dim=0, index=x.batch_index, reduce="mean"
             )
             auxiliary_values = {
                 name: module(pooled) for name, module in self.auxiliary_heads.items()

--- a/rogue_net/rogue_net/actor.py
+++ b/rogue_net/rogue_net/actor.py
@@ -177,6 +177,7 @@ class AutoActor(Actor):
         obs_space: ObsSpace,
         action_space: Dict[str, ActionSpace],
         d_model: int,
+        d_qk: int = 16,
         auxiliary_heads: Optional[nn.ModuleDict] = None,
         n_layer: int = 1,
     ):
@@ -186,6 +187,6 @@ class AutoActor(Actor):
             embedding_creator.create_embeddings(obs_space, d_model),
             action_space,
             Transformer(TransformerConfig(d_model=d_model, n_layer=n_layer)),
-            head_creator.create_action_heads(action_space, d_model),
+            head_creator.create_action_heads(action_space, d_model, d_qk),
             auxiliary_heads=auxiliary_heads,
         )

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -68,6 +68,7 @@ class PaddedSelectEntityActionHead(nn.Module):
     Action head for selecting entities.
     See https://github.com/entity-neural-network/incubator/pull/109 for more details.
     """
+
     def __init__(self, d_model: int, d_qk: int) -> None:
         super().__init__()
         self.d_model = d_model

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -1,9 +1,82 @@
-from typing import Dict
+from typing import Dict, Optional, Tuple
+from ragged_buffer import RaggedBufferI64
+from rogue_net.ragged_tensor import RaggedTensor
 from torch import nn
+from torch.distributions.categorical import Categorical
 import torch
 import numpy as np
-from entity_gym.environment import ActionSpace, CategoricalActionSpace
+import numpy.typing as npt
+from entity_gym.environment import (
+    ActionMaskBatch,
+    ActionSpace,
+    CategoricalActionMaskBatch,
+    CategoricalActionSpace,
+    DenseSelectEntityActionMask,
+    SelectEntityActionSpace,
+)
 from typing import Dict
+
+
+class ActionHead(nn.Module):
+    def forward(
+        self,
+        x: RaggedTensor,
+        index_offsets: RaggedBufferI64,
+        mask: ActionMaskBatch,
+        prev_actions: Optional[RaggedBufferI64],
+    ) -> Tuple[RaggedBufferI64, torch.Tensor, torch.Tensor, torch.Tensor]:
+        raise NotImplementedError()
+
+
+class CategoricalActionHead(nn.Module):
+    def __init__(self, d_model: int, n_choice: int) -> None:
+        super().__init__()
+        self.d_model = d_model
+        self.n_choice = n_choice
+        self.proj = layer_init(nn.Linear(d_model, n_choice), std=0.01)
+
+    def forward(
+        self,
+        x: RaggedTensor,
+        index_offsets: RaggedBufferI64,
+        mask: ActionMaskBatch,
+        prev_actions: Optional[RaggedBufferI64],
+    ) -> Tuple[torch.Tensor, npt.NDArray[np.int64], torch.Tensor, torch.Tensor]:
+        assert isinstance(
+            mask, CategoricalActionMaskBatch
+        ), f"Expected CategoricalActionMaskBatch, got {type(mask)}"
+        lengths = mask.actors.size1()
+        actors = torch.tensor((mask.actors + index_offsets).as_array()).to(
+            x.data.device
+        )
+        actor_embeds = x.data[x.index_map[actors]]
+        logits = self.proj(actor_embeds)
+        dist = Categorical(logits=logits)
+        if prev_actions is None:
+            action = dist.sample()
+        else:
+            action = torch.tensor(prev_actions.as_array()).to(x.data.device)
+        logprob = dist.log_prob(action)
+        entropy = dist.entropy()
+        return action, lengths, logprob, entropy
+
+
+class PaddedSelectEntityActionHead(nn.Module):
+    def __init__(self, d_model: int, d_qk: int) -> None:
+        super().__init__()
+        self.d_model = d_model
+        self.d_qk = d_qk
+        self.query_proj = nn.Linear(d_model, d_qk)
+        self.key_proj = nn.Linear(d_model, d_qk)
+
+    def forward(
+        self,
+        x: RaggedTensor,
+        index_offsets: RaggedBufferI64,
+        mask: ActionMaskBatch,
+        prev_actions: Optional[RaggedBufferI64],
+    ) -> Tuple[torch.Tensor, npt.NDArray[np.int64], torch.Tensor, torch.Tensor]:
+        raise NotImplementedError()
 
 
 def layer_init(
@@ -16,9 +89,11 @@ def layer_init(
     return layer
 
 
-def create_head_for(space: ActionSpace, d_model: int) -> nn.Module:
+def create_head_for(space: ActionSpace, d_model: int, d_qk: int) -> nn.Module:
     if isinstance(space, CategoricalActionSpace):
-        return layer_init(nn.Linear(d_model, len(space.choices)), std=0.01)
+        return CategoricalActionHead(d_model, len(space.choices))
+    elif isinstance(space, SelectEntityActionSpace):
+        return PaddedSelectEntityActionHead(d_model, d_qk)
     raise NotImplementedError()
 
 
@@ -34,5 +109,5 @@ def create_action_heads(
 ) -> nn.ModuleDict:
     action_heads = {}
     for name, space in action_space.items():
-        action_heads[name] = create_head_for(space, d_model)
+        action_heads[name] = create_head_for(space, d_model, 16)
     return nn.ModuleDict(action_heads)

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -64,6 +64,10 @@ class CategoricalActionHead(nn.Module):
 
 
 class PaddedSelectEntityActionHead(nn.Module):
+    """
+    Action head for selecting entities.
+    See https://github.com/entity-neural-network/incubator/pull/109 for more details.
+    """
     def __init__(self, d_model: int, d_qk: int) -> None:
         super().__init__()
         self.d_model = d_model

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -177,9 +177,9 @@ def create_value_head(d_model: int) -> nn.Module:
 
 
 def create_action_heads(
-    action_space: Dict[str, ActionSpace], d_model: int
+    action_space: Dict[str, ActionSpace], d_model: int, d_qk: int
 ) -> nn.ModuleDict:
     action_heads = {}
     for name, space in action_space.items():
-        action_heads[name] = create_head_for(space, d_model, 16)
+        action_heads[name] = create_head_for(space, d_model, d_qk)
     return nn.ModuleDict(action_heads)

--- a/rogue_net/rogue_net/ragged_tensor.py
+++ b/rogue_net/rogue_net/ragged_tensor.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+import torch
+
+
+@dataclass
+class RaggedTensor:
+    """
+    RaggedTensor represents a 3D tensor with a variable length sequence dimension.
+
+    Example:
+    entities in obs 0: [A0, A0, A0, B0]
+    entities in obs 1: [A1, B1, B1]
+    entities in obs 2: [A2, A2]
+
+    data = [A0, A0, A0, A1, A2, A2, B0, B1, B1]
+    index_map = [0, 1, 2, 6, 3, 7, 8, 4, 5]
+    batch_index = [0, 0, 0, 1, 2, 2, 0, 1, 1]
+    lengths = [4, 3, 2]
+    """
+
+    data: torch.Tensor
+    """Flattened tensor combining batch and sequence dimension of shape (entities, features)"""
+    index_map: torch.Tensor
+    """Maps the index of entities sorted first by batch index then by entity type to their index in `data`"""
+    batch_index: torch.Tensor
+    """Gives the batch index of each entity in `data`"""
+    lengths: torch.Tensor
+    """Gives the number of entities in each observation"""


### PR DESCRIPTION
This PR implements an action head for SelectEntity actions which computes a query vector for each actor and a key vector for each selectable entity (actee) using a linear projection of the embedding of the actor/actee, pads out all queries/keys to the maximum number of queries/keys in a single sample in the batch, and computes the logit of actor A selecting actee B as the dot product between the query of A and the key of B.

Fixes https://github.com/entity-neural-network/incubator/issues/19 and makes it possible to attempt https://github.com/entity-neural-network/incubator/issues/48 and https://github.com/entity-neural-network/incubator/issues/49

![Padded select entity action head(1)](https://user-images.githubusercontent.com/12845088/145058088-ae42f5f5-2782-4247-bcf5-8270a14e3510.png)


