### PR TITLE
Bam4d/generic entity ids

### DIFF
--- a/enn_zoo/enn_zoo/griddly/__init__.py
+++ b/enn_zoo/enn_zoo/griddly/__init__.py
@@ -5,7 +5,7 @@ from typing import Tuple, Type, Dict, Optional, Any
 from enn_zoo.griddly.wrapper import GriddlyEnv
 from entity_gym.environment import ActionSpace, ObsSpace, Entity, CategoricalActionSpace
 from entity_gym.environment import Environment
-from griddly import GymWrapper
+from griddly import GymWrapper, gd
 
 init_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -72,6 +72,8 @@ def create_env(
                 yaml_file=yaml_file,
                 image_path=image_path,
                 shader_path=shader_path,
+                player_observer_type=gd.ObserverType.NONE,
+                global_observer_type=gd.ObserverType.NONE,
                 level=level,
             )
 

--- a/enn_zoo/enn_zoo/griddly/env_descriptions/clusters.yaml
+++ b/enn_zoo/enn_zoo/griddly/env_descriptions/clusters.yaml
@@ -17,6 +17,8 @@ Environment:
     Lose:
       - eq: [ broken_box:count, 1 ]
       - eq: [ avatar:count, 0 ]
+      - gte: [ _steps, 500]
+
   Levels:
     - |
       w w w w w w w w w w w w w

--- a/enn_zoo/enn_zoo/griddly/wrapper.py
+++ b/enn_zoo/enn_zoo/griddly/wrapper.py
@@ -68,7 +68,7 @@ class GriddlyEnv(Environment):
         action_masks = {}
         for action_name, entity_mask in entity_masks.items():
             action_masks[action_name] = DenseCategoricalActionMask(
-                actors=np.array(entity_mask['ActorIdx']),
+                actors=np.array(entity_mask["ActorIdx"]),
                 mask=np.array(entity_mask["Masks"], dtype=np.float32),
             )
 

--- a/enn_zoo/enn_zoo/griddly/wrapper.py
+++ b/enn_zoo/enn_zoo/griddly/wrapper.py
@@ -8,6 +8,7 @@ from entity_gym.environment import (
     Action,
     Observation,
     ActionSpace,
+    EpisodeStats,
     DenseCategoricalActionMask,
     ObsSpace,
     ActionMask,
@@ -63,10 +64,11 @@ class GriddlyEnv(Environment):
         entities = {
             name: np.array(obs, dtype=np.float32) for name, obs in entities.items()
         }
+
         action_masks = {}
         for action_name, entity_mask in entity_masks.items():
             action_masks[action_name] = DenseCategoricalActionMask(
-                actors=np.array([0]),
+                actors=np.array(entity_mask['ActorIdx']),
                 mask=np.array(entity_mask["Masks"], dtype=np.float32),
             )
 
@@ -76,15 +78,24 @@ class GriddlyEnv(Environment):
             action_masks=action_masks,
             reward=reward,
             done=done,
+            end_of_episode_info=EpisodeStats(self.step, self.total_reward)
+            if done
+            else None,
         )
 
     def _reset(self) -> Observation:
         self._env.reset()
+
+        self.total_reward = 0
+        self.step = 0
 
         return self._make_observation()
 
     def _act(self, action: Mapping[str, Action]) -> Observation:
         g_action = self._to_griddly_action(action)
         _, reward, done, info = self._env.step(g_action)
+
+        self.total_reward += reward
+        self.step += 1
 
         return self._make_observation(reward, done)

--- a/enn_zoo/pyproject.toml
+++ b/enn_zoo/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-griddly = {version = "^1.2.17"}
+griddly = {version = "^1.2.19"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/enn_zoo/pyproject.toml
+++ b/enn_zoo/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-griddly = {version = "^1.2.20"}
+griddly = {version = "^1.2.21"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/enn_zoo/pyproject.toml
+++ b/enn_zoo/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-griddly = {version = "^1.2.19"}
+griddly = {version = "^1.2.20"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -71,6 +71,7 @@ class DenseSelectEntityActionMask(ActionMask):
     agent i can select entity j.
     """
 
+
 EntityID = Any
 
 

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -71,8 +71,6 @@ class DenseSelectEntityActionMask(ActionMask):
     agent i can select entity j.
     """
 
-
-# TODO: This actually cannot be 'any' type it sepcifically needs to be an integer.
 EntityID = Any
 
 

--- a/entity_gym/entity_gym/envs/cherry_pick.py
+++ b/entity_gym/entity_gym/envs/cherry_pick.py
@@ -55,7 +55,9 @@ class CherryPick(Environment):
         self.last_reward = 0.0
         self.step = 0
         self.total_reward = 0.0
-        self.ids: Sequence[EntityID] = [f'Cherry {a}' for a in range(1, len(self.cherries)+1)]+ ["Player"]
+        self.ids: List[EntityID] = [
+            f"Cherry {a}" for a in range(1, len(self.cherries) + 1)
+        ] + ["Player"]
         return self.observe()
 
     def observe(self) -> Observation:
@@ -82,7 +84,7 @@ class CherryPick(Environment):
             else None,
         )
 
-    def _entityID_to_idx(self, id: EntityID) -> None:
+    def _entityID_to_idx(self, id: EntityID) -> int:
         return self.ids.index(id)
 
     def _act(self, action: Mapping[str, Action]) -> Observation:

--- a/entity_gym/entity_gym/envs/cherry_pick.py
+++ b/entity_gym/entity_gym/envs/cherry_pick.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Mapping
 from entity_gym.environment import (
     DenseSelectEntityActionMask,
     Entity,
+    EntityID,
     Environment,
     EpisodeStats,
     ObsSpace,
@@ -54,6 +55,7 @@ class CherryPick(Environment):
         self.last_reward = 0.0
         self.step = 0
         self.total_reward = 0.0
+        self.ids: Sequence[EntityID] = [f'Cherry {a}' for a in range(1, len(self.cherries)+1)]+ ["Player"]
         return self.observe()
 
     def observe(self) -> Observation:
@@ -63,7 +65,7 @@ class CherryPick(Environment):
                 "Cherry": np.array(self.cherries, dtype=np.float32).reshape(-1, 1),
                 "Player": np.zeros([1, 0], dtype=np.float32),
             },
-            ids=np.arange(len(self.cherries) + 1),
+            ids=self.ids,
             action_masks={
                 "Pick Cherry": DenseSelectEntityActionMask(
                     actors=np.array([len(self.cherries)]),
@@ -80,11 +82,16 @@ class CherryPick(Environment):
             else None,
         )
 
+    def _entityID_to_idx(self, id: EntityID) -> None:
+        return self.ids.index(id)
+
     def _act(self, action: Mapping[str, Action]) -> Observation:
         assert len(action) == 1
         a = action["Pick Cherry"]
         assert isinstance(a, SelectEntityAction)
-        self.last_reward = self.cherries.pop(a.actions[0][1])
+        chosen_cherry_idx = self._entityID_to_idx(a.actions[0][1])
+        self.last_reward = self.cherries.pop(chosen_cherry_idx)
+        self.ids.pop(chosen_cherry_idx)
         self.total_reward += self.last_reward
         self.step += 1
         return self.observe()

--- a/entity_gym/entity_gym/envs/count.py
+++ b/entity_gym/entity_gym/envs/count.py
@@ -84,7 +84,7 @@ class Count(Environment):
             action_masks={
                 "count": DenseCategoricalActionMask(actors=np.array([0]), mask=None),
             },
-            ids=["Player"] + [f"Bean{i}" for i in range(1, self.count+1)],
+            ids=["Player"] + [f"Bean{i}" for i in range(1, self.count + 1)],
             reward=reward,
             done=done,
             end_of_episode_info=EpisodeStats(1, reward) if done else None,

--- a/entity_gym/entity_gym/envs/count.py
+++ b/entity_gym/entity_gym/envs/count.py
@@ -84,7 +84,7 @@ class Count(Environment):
             action_masks={
                 "count": DenseCategoricalActionMask(actors=np.array([0]), mask=None),
             },
-            ids=list(range(1 + self.count)),
+            ids=["Player"] + [f"Bean{i}" for i in range(1, self.count+1)],
             reward=reward,
             done=done,
             end_of_episode_info=EpisodeStats(1, reward) if done else None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -194,7 +194,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-griddly = "^1.2.20"
+griddly = "^1.2.21"
 
 [package.source]
 type = "directory"
@@ -275,7 +275,7 @@ tool = ["click (>=6.0.0)"]
 
 [[package]]
 name = "griddly"
-version = "1.2.20"
+version = "1.2.21"
 description = "Griddly Python Libraries"
 category = "main"
 optional = false
@@ -1121,7 +1121,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "baecbbd4d8325a2a863825e820701f9c54df9f792059fb27397a29b2bbbdadf6"
+content-hash = "a010ba83e4bb676e5bcd94ca9031ed308369d9dcb534f90f4865d2b39abc6e47"
 
 [metadata.files]
 absl-py = [
@@ -1204,15 +1204,15 @@ google-auth-oauthlib = [
     {file = "google_auth_oauthlib-0.4.6-py2.py3-none-any.whl", hash = "sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73"},
 ]
 griddly = [
-    {file = "griddly-1.2.20-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:73469214a82e9d5e5dee5380235b7aaab7b53da83bfa01660431307dce540ff6"},
-    {file = "griddly-1.2.20-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7442f3df2d4663ce6a513f9d3528ce62e00f9237f6c6a9e00b58924f4032164c"},
-    {file = "griddly-1.2.20-cp37-cp37m-win_amd64.whl", hash = "sha256:af131c080c4c300881f06e2cc7a519439747288323577a70bcdd46709fdacd53"},
-    {file = "griddly-1.2.20-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:e227cd8472d47eed3e560456a3a551faedcd45b5bade1536627003ba99e28be0"},
-    {file = "griddly-1.2.20-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:b43a75c7fa7ba07fe8abe773c3e1696b1416fb0686cea1bfeca65f581c8009d8"},
-    {file = "griddly-1.2.20-cp38-cp38-win_amd64.whl", hash = "sha256:97da5fc9674d6d70a409224dbc0a3a4645632497df5134fb3c38e503339aacbe"},
-    {file = "griddly-1.2.20-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:53f369bde949bae4f8a3dfa523b55783cfd727a46f202a071238b18e720173cc"},
-    {file = "griddly-1.2.20-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:35209a9009a79df014310476d32ac64294e682543f7f71d30d71eac443a7aa74"},
-    {file = "griddly-1.2.20-cp39-cp39-win_amd64.whl", hash = "sha256:5ab68f2677f7eb168f3ad34be71c2f9ba0fbcae035eed0ad182eb152f97255f5"},
+    {file = "griddly-1.2.21-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:b655da94ab46e9aacacd2ac8ac8e0c7a489281e310733bc501e2d7bc20341122"},
+    {file = "griddly-1.2.21-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:a8b2bd42e6d973968d6b0560a39facf3f375d11a6c20d113615a63e6642b8b5a"},
+    {file = "griddly-1.2.21-cp37-cp37m-win_amd64.whl", hash = "sha256:e831c6f4f5a73b33dae2d78820c0c13d909f30c029f72b58663e0ed983e70765"},
+    {file = "griddly-1.2.21-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:c998cb1c8f985f9c7de0a25d42311b90e046c857bf47370691bb082295051b0b"},
+    {file = "griddly-1.2.21-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:34d33ae01c4737e5fa8400b747a21a76d81f4dfa380d5e90a6ae3b21d63d2a12"},
+    {file = "griddly-1.2.21-cp38-cp38-win_amd64.whl", hash = "sha256:c002ecd05443255ad29c2c14692beff6e596d1a5d44dd54c22dc71084bf613b8"},
+    {file = "griddly-1.2.21-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:b17621fb3803918466fd13189f79a44cdb9d674357fbf54b7a554ea0843776db"},
+    {file = "griddly-1.2.21-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:600f441279bec91af16cbcfec8e1ab52b0195d7f24235281e8dab095a6bfe4e3"},
+    {file = "griddly-1.2.21-cp39-cp39-win_amd64.whl", hash = "sha256:e2d4b86ce2c41f5afa2b05891e7504198657899e165a1e14f330f357a896cb73"},
 ]
 grpcio = [
     {file = "grpcio-1.42.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:6e5eec67909795f7b1ff2bd941bd6c2661ca5217ea9c35003d73314100786f60"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -194,7 +194,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-griddly = "^1.2.19"
+griddly = "^1.2.20"
 
 [package.source]
 type = "directory"
@@ -275,7 +275,7 @@ tool = ["click (>=6.0.0)"]
 
 [[package]]
 name = "griddly"
-version = "1.2.19"
+version = "1.2.20"
 description = "Griddly Python Libraries"
 category = "main"
 optional = false
@@ -1121,7 +1121,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "5e3acfc72d0af027ef5700f26e7f0c19327ea3da47479abbdde95123aaf42e8a"
+content-hash = "baecbbd4d8325a2a863825e820701f9c54df9f792059fb27397a29b2bbbdadf6"
 
 [metadata.files]
 absl-py = [
@@ -1204,17 +1204,15 @@ google-auth-oauthlib = [
     {file = "google_auth_oauthlib-0.4.6-py2.py3-none-any.whl", hash = "sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73"},
 ]
 griddly = [
-    {file = "griddly-1.2.19-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:6ff61192c494e892dda784684828e407f04ea8e4331c2059523492dc1f3ed587"},
-    {file = "griddly-1.2.19-cp36-cp36m-win_amd64.whl", hash = "sha256:f14d42c53eb295b20e81ab789290fb4f82ca12fdcee165879ba60cc7f1833ea7"},
-    {file = "griddly-1.2.19-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:de4da1553a5f9ffa9b0f6e22ff2ef182c387142c66824ca0ad1b3dc2a66ffc5d"},
-    {file = "griddly-1.2.19-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:07a3d2f83a95f2d7ed9fc2314a999d90074baa4ee531231a7d228bdbdc4924a0"},
-    {file = "griddly-1.2.19-cp37-cp37m-win_amd64.whl", hash = "sha256:1c613b0699d3242af4558680ddf7de3ee852f518a3a3556de168e539e5e4ee3c"},
-    {file = "griddly-1.2.19-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:8bbd7405553a1be19c3920891ab4d1d9259f6f6b5c505bf0a329bf385c125b0b"},
-    {file = "griddly-1.2.19-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:724b3e9df41a9d1173418f50eed68d208dc2327509fb88a6183d7dfd44b4a32c"},
-    {file = "griddly-1.2.19-cp38-cp38-win_amd64.whl", hash = "sha256:39f4bca1415c9caa2697053db84e156082d66328f3e0f0e6c031a7899b3302c0"},
-    {file = "griddly-1.2.19-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:9af46775e2422954f6f3269fd5bbcd9160f1374f4d13958139357f174823fc53"},
-    {file = "griddly-1.2.19-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:418d6a76300d9530ea98c1c9ac9604c6884375e9a4f3d85878d9a61e670bbd57"},
-    {file = "griddly-1.2.19-cp39-cp39-win_amd64.whl", hash = "sha256:fc345d34f3364f95ab115fb4f0c4f957dc9a20da01890972b6c199bc435e229d"},
+    {file = "griddly-1.2.20-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:73469214a82e9d5e5dee5380235b7aaab7b53da83bfa01660431307dce540ff6"},
+    {file = "griddly-1.2.20-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7442f3df2d4663ce6a513f9d3528ce62e00f9237f6c6a9e00b58924f4032164c"},
+    {file = "griddly-1.2.20-cp37-cp37m-win_amd64.whl", hash = "sha256:af131c080c4c300881f06e2cc7a519439747288323577a70bcdd46709fdacd53"},
+    {file = "griddly-1.2.20-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:e227cd8472d47eed3e560456a3a551faedcd45b5bade1536627003ba99e28be0"},
+    {file = "griddly-1.2.20-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:b43a75c7fa7ba07fe8abe773c3e1696b1416fb0686cea1bfeca65f581c8009d8"},
+    {file = "griddly-1.2.20-cp38-cp38-win_amd64.whl", hash = "sha256:97da5fc9674d6d70a409224dbc0a3a4645632497df5134fb3c38e503339aacbe"},
+    {file = "griddly-1.2.20-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:53f369bde949bae4f8a3dfa523b55783cfd727a46f202a071238b18e720173cc"},
+    {file = "griddly-1.2.20-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:35209a9009a79df014310476d32ac64294e682543f7f71d30d71eac443a7aa74"},
+    {file = "griddly-1.2.20-cp39-cp39-win_amd64.whl", hash = "sha256:5ab68f2677f7eb168f3ad34be71c2f9ba0fbcae035eed0ad182eb152f97255f5"},
 ]
 grpcio = [
     {file = "grpcio-1.42.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:6e5eec67909795f7b1ff2bd941bd6c2661ca5217ea9c35003d73314100786f60"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -194,7 +194,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-griddly = "^1.2.17"
+griddly = "^1.2.19"
 
 [package.source]
 type = "directory"
@@ -275,7 +275,7 @@ tool = ["click (>=6.0.0)"]
 
 [[package]]
 name = "griddly"
-version = "1.2.17"
+version = "1.2.19"
 description = "Griddly Python Libraries"
 category = "main"
 optional = false
@@ -336,7 +336,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imageio"
-version = "2.13.2"
+version = "2.13.3"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
 optional = false
@@ -645,7 +645,7 @@ test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchm
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.23"
+version = "3.0.24"
 description = "Library for building powerful interactive command lines in Python"
 category = "dev"
 optional = false
@@ -1121,7 +1121,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "aad1a97031a2348c51b7cd1db75efd665de8c382e0fd1c8f826a760f600e9af6"
+content-hash = "5e3acfc72d0af027ef5700f26e7f0c19327ea3da47479abbdde95123aaf42e8a"
 
 [metadata.files]
 absl-py = [
@@ -1204,18 +1204,17 @@ google-auth-oauthlib = [
     {file = "google_auth_oauthlib-0.4.6-py2.py3-none-any.whl", hash = "sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73"},
 ]
 griddly = [
-    {file = "griddly-1.2.17-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:799a3264073eba04801672e988c77bd4b3ae39e2144760628263212e290750c6"},
-    {file = "griddly-1.2.17-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:5248c0b206902a9af3128bb536d1f9638fa8d075c3887db2d0208c0b64efd6e7"},
-    {file = "griddly-1.2.17-cp36-cp36m-win_amd64.whl", hash = "sha256:020674e46e26f61b01cb6015276b3c1afa093a0d168fbe08d05c287b76a7ff5f"},
-    {file = "griddly-1.2.17-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:962b18de0ae9b6a56fdade0ebc5a59a360bbfc26c5d3dc336cec6ca9dd2fa300"},
-    {file = "griddly-1.2.17-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:e173e683c0e69a10ad8dbd98e223f1bdb9102ad5c9c2da69213dcecf7927ffc8"},
-    {file = "griddly-1.2.17-cp37-cp37m-win_amd64.whl", hash = "sha256:c53b589e2707ea5ab62d3b2281890f1406fa84e142ba652d588830432b35d8cd"},
-    {file = "griddly-1.2.17-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:42eda54cbbe68858c73b81b30715aaade3f756ecaf50802dad17d0d3c6678121"},
-    {file = "griddly-1.2.17-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:70928b40ab93f639dac8349b7b29105c9203f9890b7f0cc1e87b2bdeb55b49b7"},
-    {file = "griddly-1.2.17-cp38-cp38-win_amd64.whl", hash = "sha256:8198769a4eeba082557bc0539680afdafd052daedf3b73b24e9f7b9ec64c5a0b"},
-    {file = "griddly-1.2.17-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:2c1005f36a0c2965366625aaae365fed8ab364c76054cacb9937e8adf074e920"},
-    {file = "griddly-1.2.17-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:24218cf55b243e1490fb8834e58e7872e4a619c13b76182c41f544a7a33b2ef0"},
-    {file = "griddly-1.2.17-cp39-cp39-win_amd64.whl", hash = "sha256:e3e6aedab50c4e461bb44cf80ec9e8767a5c4f558d8c1cecc9dd770e48747e44"},
+    {file = "griddly-1.2.19-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:6ff61192c494e892dda784684828e407f04ea8e4331c2059523492dc1f3ed587"},
+    {file = "griddly-1.2.19-cp36-cp36m-win_amd64.whl", hash = "sha256:f14d42c53eb295b20e81ab789290fb4f82ca12fdcee165879ba60cc7f1833ea7"},
+    {file = "griddly-1.2.19-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:de4da1553a5f9ffa9b0f6e22ff2ef182c387142c66824ca0ad1b3dc2a66ffc5d"},
+    {file = "griddly-1.2.19-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:07a3d2f83a95f2d7ed9fc2314a999d90074baa4ee531231a7d228bdbdc4924a0"},
+    {file = "griddly-1.2.19-cp37-cp37m-win_amd64.whl", hash = "sha256:1c613b0699d3242af4558680ddf7de3ee852f518a3a3556de168e539e5e4ee3c"},
+    {file = "griddly-1.2.19-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:8bbd7405553a1be19c3920891ab4d1d9259f6f6b5c505bf0a329bf385c125b0b"},
+    {file = "griddly-1.2.19-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:724b3e9df41a9d1173418f50eed68d208dc2327509fb88a6183d7dfd44b4a32c"},
+    {file = "griddly-1.2.19-cp38-cp38-win_amd64.whl", hash = "sha256:39f4bca1415c9caa2697053db84e156082d66328f3e0f0e6c031a7899b3302c0"},
+    {file = "griddly-1.2.19-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:9af46775e2422954f6f3269fd5bbcd9160f1374f4d13958139357f174823fc53"},
+    {file = "griddly-1.2.19-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:418d6a76300d9530ea98c1c9ac9604c6884375e9a4f3d85878d9a61e670bbd57"},
+    {file = "griddly-1.2.19-cp39-cp39-win_amd64.whl", hash = "sha256:fc345d34f3364f95ab115fb4f0c4f957dc9a20da01890972b6c199bc435e229d"},
 ]
 grpcio = [
     {file = "grpcio-1.42.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:6e5eec67909795f7b1ff2bd941bd6c2661ca5217ea9c35003d73314100786f60"},
@@ -1271,8 +1270,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imageio = [
-    {file = "imageio-2.13.2-py3-none-any.whl", hash = "sha256:4acc2a2d0210170ee109c59edc178cee818c87f0a33a2a35116a19e3ac7badc0"},
-    {file = "imageio-2.13.2.tar.gz", hash = "sha256:5b7a55d07de88a2fd70f18a1608ca05ba2b55596a942fb2c390240201009a6c3"},
+    {file = "imageio-2.13.3-py3-none-any.whl", hash = "sha256:126f10aa970f54b657bcc52f6481a2e55137fcc0f978bb6e0451bd1e22c54f17"},
+    {file = "imageio-2.13.3.tar.gz", hash = "sha256:bb87b272e1e9b05d242e11f8d88d030aefa68ca95daf3accc986d0b782ae3cd5"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
@@ -1484,8 +1483,8 @@ promise = [
     {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.23-py3-none-any.whl", hash = "sha256:5f29d62cb7a0ecacfa3d8ceea05a63cd22500543472d64298fc06ddda906b25d"},
-    {file = "prompt_toolkit-3.0.23.tar.gz", hash = "sha256:7053aba00895473cb357819358ef33f11aa97e4ac83d38efb123e5649ceeecaf"},
+    {file = "prompt_toolkit-3.0.24-py3-none-any.whl", hash = "sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506"},
+    {file = "prompt_toolkit-3.0.24.tar.gz", hash = "sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6"},
 ]
 protobuf = [
     {file = "protobuf-3.19.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d80f80eb175bf5f1169139c2e0c5ada98b1c098e2b3c3736667f28cbbea39fc8"},
@@ -1634,10 +1633,15 @@ pyyaml = [
 ]
 ragged-buffer = [
     {file = "ragged_buffer-0.2.10-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:cab38efd4c5edba23626a3a38595607bfd82e85ce7556df73826d970558f46c0"},
+    {file = "ragged_buffer-0.2.10-cp310-none-win_amd64.whl", hash = "sha256:43524b1a3d90da57439fd449a85fe510f5ae300c4a320e679f2dc44b01b7d2bf"},
+    {file = "ragged_buffer-0.2.10-cp36-none-win_amd64.whl", hash = "sha256:ea13b75e12fd1079e84c06691a7966be57d0e07810c01474dff6961f35a3c664"},
     {file = "ragged_buffer-0.2.10-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:ce5e07335bb133ddd8b6c7f60bd8eff5737e91ce58da31e9bd4b2ddca6bfa027"},
+    {file = "ragged_buffer-0.2.10-cp37-none-win_amd64.whl", hash = "sha256:5feb9d282ad4bd9599e8d71654ce1419f213006fd86291b81963b88075f6a833"},
     {file = "ragged_buffer-0.2.10-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:93484877250abdd8d8c496e2b4b840a8d531390ed451cd512407ebb4aa8df8ce"},
     {file = "ragged_buffer-0.2.10-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:bbc074ec1fee2a1cc0b6c8c8b351152e11e17cc1b0e6f6218d4af10bcebf04d2"},
+    {file = "ragged_buffer-0.2.10-cp38-none-win_amd64.whl", hash = "sha256:1c84ddb2e396d86c009127673926cfa764df8f58120f0b58504d27da3cae4fe2"},
     {file = "ragged_buffer-0.2.10-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:b3e3b5b1cf8979693ce72741fcd7756df1a276adab0c6b71583e88512af71abe"},
+    {file = "ragged_buffer-0.2.10-cp39-none-win_amd64.whl", hash = "sha256:2579d231de52f3e335ec10bffaa6540889a5c4397cc77d33f28fa332dbcd69f7"},
     {file = "ragged_buffer-0.2.10.tar.gz", hash = "sha256:699c6ce8c76f9e7153c394ad16855042c58fed6f082194110147c80cac0abbb4"},
 ]
 requests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ entity_gym = {path = "entity_gym", develop = true}
 rogue_net = {path = "rogue_net", develop = true}
 enn_ppo = {path = "enn_ppo", develop = true}
 enn_zoo = {path = "enn_zoo", develop = true}
-griddly = {version = "^1.2.19"}
+griddly = {version = "^1.2.20"}
 # torch-scatter = {url = "https://data.pyg.org/whl/torch-1.10.0%2Bcu102/torch_scatter-2.0.9-cp38-cp38-linux_x86_64.whl"}
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ entity_gym = {path = "entity_gym", develop = true}
 rogue_net = {path = "rogue_net", develop = true}
 enn_ppo = {path = "enn_ppo", develop = true}
 enn_zoo = {path = "enn_zoo", develop = true}
-griddly = {version = "^1.2.17"}
+griddly = {version = "^1.2.19"}
 # torch-scatter = {url = "https://data.pyg.org/whl/torch-1.10.0%2Bcu102/torch_scatter-2.0.9-cp38-cp38-linux_x86_64.whl"}
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ entity_gym = {path = "entity_gym", develop = true}
 rogue_net = {path = "rogue_net", develop = true}
 enn_ppo = {path = "enn_ppo", develop = true}
 enn_zoo = {path = "enn_zoo", develop = true}
-griddly = {version = "^1.2.20"}
+griddly = {version = "^1.2.21"}
 # torch-scatter = {url = "https://data.pyg.org/whl/torch-1.10.0%2Bcu102/torch_scatter-2.0.9-cp38-cp38-linux_x86_64.whl"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
More information on this in here -> #74 

I've also modified the "cherry-pick" env and the "count" env to use strings as entityIDs as tests for guaranteeing #74.

Also Griddly now partially trains using EntityIDs that are hashes of underlying pointers in c++. HOWEVER.... it still cannot solve the environment. At the moment, the agent learns to avoid the spikes (which kill it) but does not learn to actually create any "clusters".

I'm not sure whether this is a tuning issue, or an underlying bug or limitation of the pooling layers. I could do with some more perspective from @cswinter or anyone who knows more about the pooling implementation.

![image](https://user-images.githubusercontent.com/1370765/145673631-17eae8a3-c34a-41d8-ae60-0fb94001b883.png)



Closes #14 