### PR TITLE
Parallel Environment Execution

### DIFF
--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -27,6 +27,7 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     DenseSelectEntityActionMask,
     EnvList,
+    BatchEnv,
     Environment,
     ParallelEnvList,
     ObsSpace,
@@ -247,10 +248,15 @@ def train(args: argparse.Namespace) -> float:
 
     # env setup
     env_kwargs = json.loads(args.env_kwargs)
+    envs: BatchEnv
     if args.processes > 1:
-        envs = ParallelEnvList(env_cls, env_kwargs, args.num_envs, args.processes) #[instantiate_env for _ in range(args.num_envs)])  # type: ignore
+        envs = ParallelEnvList(
+            env_cls, env_kwargs, args.num_envs, args.processes
+        )
     else:
-        envs = EnvList(env_cls, env_kwargs, args.num_envs) #'[env_cls(**env_kwargs) for _ in range(args.num_envs)])  # type: ignore
+        envs = EnvList(
+            env_cls, env_kwargs, args.num_envs
+        )
     obs_space = env_cls.obs_space()
     action_space = env_cls.action_space()
     if args.capture_samples:

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -250,13 +250,9 @@ def train(args: argparse.Namespace) -> float:
     env_kwargs = json.loads(args.env_kwargs)
     envs: BatchEnv
     if args.processes > 1:
-        envs = ParallelEnvList(
-            env_cls, env_kwargs, args.num_envs, args.processes
-        )
+        envs = ParallelEnvList(env_cls, env_kwargs, args.num_envs, args.processes)
     else:
-        envs = EnvList(
-            env_cls, env_kwargs, args.num_envs
-        )
+        envs = EnvList(env_cls, env_kwargs, args.num_envs)
     obs_space = env_cls.obs_space()
     action_space = env_cls.action_space()
     if args.capture_samples:

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -27,7 +27,6 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     DenseSelectEntityActionMask,
     EnvList,
-    BatchEnv,
     Environment,
     ParallelEnvList,
     ObsSpace,

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -27,6 +27,7 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     DenseSelectEntityActionMask,
     EnvList,
+    VecEnv,
     Environment,
     ParallelEnvList,
     ObsSpace,
@@ -247,7 +248,7 @@ def train(args: argparse.Namespace) -> float:
 
     # env setup
     env_kwargs = json.loads(args.env_kwargs)
-    envs: BatchEnv
+    envs: VecEnv
     if args.processes > 1:
         envs = ParallelEnvList(env_cls, env_kwargs, args.num_envs, args.processes)
     else:

--- a/enn_ppo/pyproject.toml
+++ b/enn_ppo/pyproject.toml
@@ -13,7 +13,7 @@ msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 tqdm = "^4.62.3"
 torch-scatter = "^2.0.9"
-ragged-buffer = "^0.2.10"
+ragged-buffer = "^0.2.11"
 wandb = "^0.12.7"
 enn_zoo = {path = "../enn_zoo", develop=true}
 entity_gym = {path = "../entity_gym", develop = true}

--- a/enn_zoo/enn_zoo/griddly/wrapper.py
+++ b/enn_zoo/enn_zoo/griddly/wrapper.py
@@ -69,7 +69,7 @@ class GriddlyEnv(Environment):
         for action_name, entity_mask in entity_masks.items():
             action_masks[action_name] = DenseCategoricalActionMask(
                 actors=np.array(entity_mask["ActorIdx"]),
-                mask=np.array(entity_mask["Masks"], dtype=np.float32),
+                mask=np.array(entity_mask["Masks"]).astype(np.bool),
             )
 
         return Observation(

--- a/enn_zoo/enn_zoo/griddly/wrapper.py
+++ b/enn_zoo/enn_zoo/griddly/wrapper.py
@@ -69,7 +69,7 @@ class GriddlyEnv(Environment):
         for action_name, entity_mask in entity_masks.items():
             action_masks[action_name] = DenseCategoricalActionMask(
                 actors=np.array(entity_mask["ActorIdx"]),
-                mask=np.array(entity_mask["Masks"]).astype(np.bool),
+                mask=np.array(entity_mask["Masks"]).astype(np.bool_),
             )
 
         return Observation(

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -348,11 +348,6 @@ def batch_obs(
 
 
 @dataclass
-class Entity:
-    features: List[str]
-
-
-@dataclass
 class CategoricalAction:
     # TODO: figure out best representation
     actions: List[Tuple[EntityID, int]]

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -346,15 +346,15 @@ class Environment(ABC):
     def env_cls(self) -> Type["Environment"]:
         return self.__class__
 
-class BatchEnv(ABC):
 
+class BatchEnv(ABC):
     @abstractmethod
     def reset(self, obs_space: ObsSpace) -> ObsBatch:
         raise NotImplementedError
 
     @abstractmethod
     def act(
-            self, actions: Sequence[Mapping[str, Action]], obs_space: ObsSpace
+        self, actions: Sequence[Mapping[str, Action]], obs_space: ObsSpace
     ) -> ObsBatch:
         raise NotImplementedError
 
@@ -414,9 +414,8 @@ class BaseEnvList(VecEnv):
 
 
 class EnvList(BatchEnv):
-
     def __init__(
-            self, env_cls: Type[Environment], env_kwargs: Dict[str, Any], num_envs: int
+        self, env_cls: Type[Environment], env_kwargs: Dict[str, Any], num_envs: int
     ):
         self.envs = BaseEnvList(env_cls, env_kwargs, num_envs)
 
@@ -548,7 +547,9 @@ class ParallelEnvList(BatchEnv):
         for process in self.processes:
             process.join()
 
-    def _chunk_actions(self, actions: Sequence[Mapping[str, Action]]) -> Generator[Sequence[Mapping[str, Action]], List[Observation], None]:
+    def _chunk_actions(
+        self, actions: Sequence[Mapping[str, Action]]
+    ) -> Generator[Sequence[Mapping[str, Action]], List[Observation], None]:
         for i in range(0, len(actions), self.envs_per_process):
             yield actions[i : i + self.envs_per_process]
 

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -241,6 +241,11 @@ def merge_obs(a: Optional[ObsBatch], b: ObsBatch) -> ObsBatch:
     reward = np.concatenate((a.reward, b.reward))
     done = np.concatenate((a.done, b.done))
 
+    for k, v in a.end_of_episode_info.items(): # type: ignore
+        end_of_episode_info[k] = v # type: ignore
+    for k, v in b.end_of_episode_info.items(): # type: ignore
+        end_of_episode_info[k] = v # type: ignore
+
     return ObsBatch(
         entities,
         ids,

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -241,10 +241,10 @@ def merge_obs(a: Optional[ObsBatch], b: ObsBatch) -> ObsBatch:
     reward = np.concatenate((a.reward, b.reward))
     done = np.concatenate((a.done, b.done))
 
-    for k, v in a.end_of_episode_info.items(): # type: ignore
-        end_of_episode_info[k] = v # type: ignore
-    for k, v in b.end_of_episode_info.items(): # type: ignore
-        end_of_episode_info[k] = v # type: ignore
+    for k, v in a.end_of_episode_info.items():  # type: ignore
+        end_of_episode_info[k] = v  # type: ignore
+    for k, v in b.end_of_episode_info.items():  # type: ignore
+        end_of_episode_info[k] = v  # type: ignore
 
     return ObsBatch(
         entities,

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -203,40 +203,26 @@ class ObsBatch:
     end_of_episode_info: Dict[int, EpisodeStats]
 
 
-def merge_obs(a: ObsBatch, b: ObsBatch) -> ObsBatch:
+def merge_obs(a: ObsBatch, b: ObsBatch) -> None:
     """
-    merges two obs_batches
+    Merges ObsBatch b into ObsBatch a
     """
-
-    entities = a.entities.copy()
-    ids = a.ids.copy()
-    action_masks = a.action_masks.copy()
-    end_of_episode_info = a.end_of_episode_info.copy()
 
     # merge entities
     for k in b.entities.keys():
-        entities[k].extend(b.entities[k])
+        a.entities[k].extend(b.entities[k])
 
     # merge ids
-    ids.extend(b.ids)
+    a.ids.extend(b.ids)
 
     # merge masks
     for k in b.action_masks.keys():
-        action_masks[k].extend(b.action_masks[k])
+        a.action_masks[k].extend(b.action_masks[k])
 
-    reward = np.concatenate((a.reward, b.reward))
-    done = np.concatenate((a.done, b.done))
+    a.reward = np.concatenate((a.reward, b.reward))
+    a.done = np.concatenate((a.done, b.done))
 
-    end_of_episode_info.update(b.end_of_episode_info)
-
-    return ObsBatch(
-        entities,
-        ids,
-        action_masks,
-        np.array(reward),
-        np.array(done),
-        end_of_episode_info,
-    )
+    a.end_of_episode_info.update(b.end_of_episode_info)
 
 
 def batch_obs(
@@ -672,7 +658,7 @@ class ParallelEnvList(VecEnv):
 
         for remote in self.remotes:
             remote_obs_batch = remote.recv()
-            observations = merge_obs(observations, remote_obs_batch)
+            merge_obs(observations, remote_obs_batch)
 
         assert isinstance(observations, ObsBatch)
         return observations
@@ -701,5 +687,5 @@ class ParallelEnvList(VecEnv):
 
         for remote in self.remotes:
             remote_obs_batch = remote.recv()
-            observations = merge_obs(observations, remote_obs_batch)
+            merge_obs(observations, remote_obs_batch)
         return observations

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -121,7 +121,7 @@ class CategoricalActionMaskBatch:
     def __getitem__(
         self, i: Union[int, npt.NDArray[np.int64]]
     ) -> "CategoricalActionMaskBatch":
-        if self.masks is not None:
+        if self.masks is not None and self.masks.size0() > 0:
             return CategoricalActionMaskBatch(self.actors[i], self.masks[i])
         else:
             return CategoricalActionMaskBatch(self.actors[i], None)

--- a/entity_gym/entity_gym/envs/count.py
+++ b/entity_gym/entity_gym/envs/count.py
@@ -65,8 +65,8 @@ class Count(Environment):
                 range(0, self.masked_choices), random.randint(0, self.masked_choices)
             ),
         }
-        mask = np.zeros((10), dtype=np.int64)
-        mask[list(possible_counts)] = 1
+        mask = np.zeros((10), dtype=np.bool)
+        mask[list(possible_counts)] = True
         return self.observe(obs_space, mask)
 
     def _reset(self) -> Observation:

--- a/entity_gym/entity_gym/envs/count.py
+++ b/entity_gym/entity_gym/envs/count.py
@@ -65,7 +65,7 @@ class Count(Environment):
                 range(0, self.masked_choices), random.randint(0, self.masked_choices)
             ),
         }
-        mask = np.zeros((10), dtype=np.bool)
+        mask = np.zeros((10), dtype=np.bool_)
         mask[list(possible_counts)] = True
         return self.observe(obs_space, mask)
 

--- a/entity_gym/entity_gym/test_environment.py
+++ b/entity_gym/entity_gym/test_environment.py
@@ -311,7 +311,8 @@ def test_batch_obs_categorical_action() -> None:
         obs_batch.action_masks["choose_inventory_item"], CategoricalActionMaskBatch
     )
 
-    assert isinstance(obs_batch.action_masks["move"].masks, np.ndarray)
+    assert obs_batch.action_masks["move"].masks is not None
+    assert obs_batch.action_masks["choose_inventory_item"].masks is not None
 
     assert np.all(obs_batch.action_masks["move"].actors.size1() == np.array([2, 3, 0]))
     assert np.all(obs_batch.action_masks["move"].masks.size1() == np.array([2, 3, 0]))
@@ -346,7 +347,7 @@ def test_merge_obs_entities() -> None:
                 lengths=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
             ),
         },
-        ids=[f"entity1_{i}" for i in range(10)] + [f"entity2_{i}" for i in range(10)],
+        ids=[["entity1_0"] * 10],
         action_masks={},
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
@@ -364,7 +365,7 @@ def test_merge_obs_entities() -> None:
                 lengths=np.array([0, 0, 1, 1, 0, 2, 3, 3, 0, 0]),
             ),
         },
-        ids=[f"entity1_{i}" for i in range(10)] + [f"entity2_{i}" for i in range(10)],
+        ids=[["entity2_0"] * 10],
         action_masks={},
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),

--- a/entity_gym/entity_gym/test_environment.py
+++ b/entity_gym/entity_gym/test_environment.py
@@ -372,14 +372,14 @@ def test_merge_obs_entities() -> None:
         end_of_episode_info={},
     )
 
-    merged_obs = merge_obs(obs_batch1, obs_batch2)
+    merge_obs(obs_batch1, obs_batch2)
 
     assert np.all(
-        merged_obs.entities["entity1"].size1()
+        obs_batch1.entities["entity1"].size1()
         == [0, 0, 1, 1, 0, 2, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     )
     assert np.all(
-        merged_obs.entities["entity2"].size1()
+        obs_batch1.entities["entity2"].size1()
         == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 2, 3, 3, 0, 0]
     )
 
@@ -498,16 +498,16 @@ def test_merge_obs_actions_categorical() -> None:
         end_of_episode_info={},
     )
 
-    merged_obs = merge_obs(obs_batch1, obs_batch2)
+    merge_obs(obs_batch1, obs_batch2)
 
-    assert isinstance(merged_obs.action_masks["action1"], CategoricalActionMaskBatch)
-    assert isinstance(merged_obs.action_masks["action2"], CategoricalActionMaskBatch)
+    assert isinstance(obs_batch1.action_masks["action1"], CategoricalActionMaskBatch)
+    assert isinstance(obs_batch1.action_masks["action2"], CategoricalActionMaskBatch)
 
     assert np.all(
-        merged_obs.action_masks["action1"].actors.size1() == [1, 2, 1, 0, 0, 0]
+        obs_batch1.action_masks["action1"].actors.size1() == [1, 2, 1, 0, 0, 0]
     )
     assert np.all(
-        merged_obs.action_masks["action2"].actors.size1() == [0, 0, 0, 1, 2, 1]
+        obs_batch1.action_masks["action2"].actors.size1() == [0, 0, 0, 1, 2, 1]
     )
 
 
@@ -615,20 +615,20 @@ def test_merge_obs_actions_select_entity() -> None:
         end_of_episode_info={},
     )
 
-    merged_obs = merge_obs(obs_batch1, obs_batch2)
+    merge_obs(obs_batch1, obs_batch2)
 
-    assert isinstance(merged_obs.action_masks["action1"], SelectEntityActionMaskBatch)
-    assert isinstance(merged_obs.action_masks["action2"], SelectEntityActionMaskBatch)
+    assert isinstance(obs_batch1.action_masks["action1"], SelectEntityActionMaskBatch)
+    assert isinstance(obs_batch1.action_masks["action2"], SelectEntityActionMaskBatch)
 
     assert np.all(
-        merged_obs.action_masks["action1"].actors.size1() == [1, 2, 1, 0, 0, 0]
+        obs_batch1.action_masks["action1"].actors.size1() == [1, 2, 1, 0, 0, 0]
     )
     assert np.all(
-        merged_obs.action_masks["action1"].actees.size1() == [2, 1, 2, 0, 0, 0]
+        obs_batch1.action_masks["action1"].actees.size1() == [2, 1, 2, 0, 0, 0]
     )
     assert np.all(
-        merged_obs.action_masks["action2"].actors.size1() == [0, 0, 0, 1, 2, 1]
+        obs_batch1.action_masks["action2"].actors.size1() == [0, 0, 0, 1, 2, 1]
     )
     assert np.all(
-        merged_obs.action_masks["action2"].actees.size1() == [0, 0, 0, 2, 1, 2]
+        obs_batch1.action_masks["action2"].actees.size1() == [0, 0, 0, 2, 1, 2]
     )

--- a/entity_gym/entity_gym/test_environment.py
+++ b/entity_gym/entity_gym/test_environment.py
@@ -1,0 +1,43 @@
+from entity_gym.envs.cherry_pick import CherryPick
+from entity_gym.environment import EnvList, ParallelEnvList
+from entity_gym.environment import (
+    SelectEntityAction,
+)
+
+
+def test_env_list() -> None:
+    env_cls = CherryPick
+
+    obs_space = env_cls.obs_space()
+
+    # 100 environments
+    envs = EnvList(env_cls, {}, 100)
+
+    obs_reset = envs.reset(obs_space)
+    assert len(obs_reset.ids) == 100
+
+    actions = [
+        {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
+    ] * 100
+    obs_act = envs.act(actions, obs_space)
+
+    assert len(obs_act.ids) == 100
+
+
+def test_parallel_env_list() -> None:
+    env_cls = CherryPick
+
+    obs_space = env_cls.obs_space()
+
+    # 100 environments split across 10 processes
+    envs = ParallelEnvList(env_cls, {}, 100, 10)
+
+    obs_reset = envs.reset(obs_space)
+    assert len(obs_reset.ids) == 100
+
+    actions = [
+        {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
+    ] * 100
+    obs_act = envs.act(actions, obs_space)
+
+    assert len(obs_act.ids) == 100

--- a/entity_gym/entity_gym/test_environment.py
+++ b/entity_gym/entity_gym/test_environment.py
@@ -14,7 +14,6 @@ from entity_gym.environment import (
     ActionSpace,
     Entity,
     batch_obs,
-    merge_obs,
 )
 import numpy as np
 from typing import Dict
@@ -372,7 +371,7 @@ def test_merge_obs_entities() -> None:
         end_of_episode_info={},
     )
 
-    merge_obs(obs_batch1, obs_batch2)
+    ObsBatch.merge_obs(obs_batch1, obs_batch2)
 
     assert np.all(
         obs_batch1.entities["entity1"].size1()
@@ -498,7 +497,7 @@ def test_merge_obs_actions_categorical() -> None:
         end_of_episode_info={},
     )
 
-    merge_obs(obs_batch1, obs_batch2)
+    ObsBatch.merge_obs(obs_batch1, obs_batch2)
 
     assert isinstance(obs_batch1.action_masks["action1"], CategoricalActionMaskBatch)
     assert isinstance(obs_batch1.action_masks["action2"], CategoricalActionMaskBatch)
@@ -615,7 +614,7 @@ def test_merge_obs_actions_select_entity() -> None:
         end_of_episode_info={},
     )
 
-    merge_obs(obs_batch1, obs_batch2)
+    ObsBatch.merge_obs(obs_batch1, obs_batch2)
 
     assert isinstance(obs_batch1.action_masks["action1"], SelectEntityActionMaskBatch)
     assert isinstance(obs_batch1.action_masks["action2"], SelectEntityActionMaskBatch)

--- a/entity_gym/entity_gym/test_environment.py
+++ b/entity_gym/entity_gym/test_environment.py
@@ -1,12 +1,16 @@
 from entity_gym.envs.cherry_pick import CherryPick
 from entity_gym.environment import EnvList, ParallelEnvList
 from entity_gym.environment import (
+    SelectEntityActionSpace,
+    CategoricalActionSpace,
+    DenseSelectEntityActionMask,
+    DenseCategoricalActionMask,
     SelectEntityAction,
     Observation,
     ObsSpace,
     Entity,
     batch_obs,
-    merge_obs
+    merge_obs,
 )
 import numpy as np
 
@@ -62,52 +66,54 @@ def test_batch_obs_entities():
         }
     )
 
+    action_space = {}
+
     observation1 = Observation(
-        {
-            "entity1": np.array([[10, 10, 10], [10, 10, 10]], np.float32)
-        },
+        {"entity1": np.array([[10, 10, 10], [10, 10, 10]], np.float32)},
         ["entity1_0", "entity1_1"],
         {},
         0.0,
         False,
-        None
+        None,
     )
 
     observation2 = Observation(
-        {
-            "entity1": np.array([[10, 10, 10]], np.float32)
-        },
+        {"entity1": np.array([[10, 10, 10]], np.float32)},
         ["entity1_0"],
         {},
         0.0,
         False,
-        None
+        None,
     )
 
-    # now we introduce the rare entity, and remove entity1
     observation3 = Observation(
         {
-            "rare": np.array([[10, 10, 10, 4, 2], [10, 10, 10, 4, 2], [10, 10, 10, 4, 2]], np.float32)
+            "rare": np.array(
+                [[10, 10, 10, 4, 2], [10, 10, 10, 4, 2], [10, 10, 10, 4, 2]], np.float32
+            )
         },
         ["rare1_0", "rare1_1", "rare1_2"],
         {},
         0.0,
         False,
-        None
+        None,
     )
 
-    obs_batch = batch_obs([observation1, observation2, observation3], obs_space)
+    obs_batch = batch_obs(
+        [observation1, observation2, observation3], obs_space, action_space
+    )
 
     # entity1 observations should have a ragged array with lengths [2, 1, 0]
     # rare observations should have a ragged array with lengths [0, 0, 3]
-    assert np.all(obs_batch.entities['entity1'].size1() == [2, 1, 0])
-    assert np.all(obs_batch.entities['rare'].size1() == [0, 0, 3])
+    assert np.all(obs_batch.entities["entity1"].size1() == [2, 1, 0])
+    assert np.all(obs_batch.entities["rare"].size1() == [0, 0, 3])
 
 
 def test_batch_obs_select_entity_action():
     """
-    We  have a set of observations and only a single one of those observations contains a paricular action and associated mask.
-    When this action is batched, it needs to needs to contain 0-length rows for that action/mask for all other observations.
+    We have three actions types that are dependent on the entities that are present in each observation
+    This is common in procedurally generated environments, where types of objects/entities can be generated randomly,
+    or in environments where there are possible rare interactions between entities.
     """
 
     obs_space = ObsSpace(
@@ -118,66 +124,84 @@ def test_batch_obs_select_entity_action():
         }
     )
 
+    action_space = {
+        "high_five": SelectEntityActionSpace(),
+        "mid_five": SelectEntityActionSpace(),
+        "low_five": SelectEntityActionSpace(),
+    }
+
     observation1 = Observation(
         {
             "entity1": np.array([[10, 10, 10]], np.float32),
-            "entity2": np.array([[10, 10, 10]], np.float32)
+            "entity2": np.array([[10, 10, 10]], np.float32),
         },
         ["entity1_0", "entity2_0"],
         {
             # entity1 can low five entity 2 and vice versa
-            "low-five": SelectEntityAction([("entity1_0", "entity2_0"), ("entity2_0", "entity1_0")])
+            "low_five": DenseSelectEntityActionMask(
+                np.array([0, 1]), np.array([1, 0]), None
+            )
         },
         0.0,
         False,
-        None
+        None,
     )
 
     observation2 = Observation(
         {
             "entity1": np.array([[10, 10, 10]], np.float32),
-            "entity2": np.array([[10, 10, 10]], np.float32)
-        },
-        ["entity1_0","entity3_0"],
-        {
-            # entity3 can high five entity 1
-            "high-five": SelectEntityAction([("entity3_0", "entity1_0")])
-        },
-        0.0,
-        False,
-        None
-    )
-
-    # now we introduce the rare entity, and remove entity1
-    observation3 = Observation(
-        {
-            "entity1": np.array([[10, 10, 10]], np.float32),
-            "entity2": np.array([[10, 10, 10]], np.float32),
-            "entity3": np.array([[10, 10, 10]], np.float32)
+            "entity3": np.array([[10, 10, 10]], np.float32),
         },
         ["entity1_0", "entity3_0"],
         {
-            # entity3 can high five entity 1, and entity 2 can mid five entity3. entity1 and entity2 can low five each other
-            "high-five": SelectEntityAction([("entity3_0", "entity1_0")]),
-            "mid-five": SelectEntityAction([("entity2_0", "entity3_0")]),
-            "low-five": SelectEntityAction([("entity1_0", "entity2_0"), ("entity2_0", "entity1_0")])
+            # entity3 can high five entity 1
+            "high_five": DenseSelectEntityActionMask(np.array([1]), np.array([0]), None)
         },
         0.0,
         False,
-        None
+        None,
     )
 
-    obs_batch = batch_obs([observation1, observation2, observation3], obs_space)
+    observation3 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10], [10, 10, 10]], np.float32),
+            "entity3": np.array([[10, 10, 10]], np.float32),
+        },
+        ["entity1_0", "entity2_0", "entity2_1", "entity3_0"],
+        {
+            # entity3 can high five entity 1, and entity 2_0 and entity 2_1 can mid five entity3. entity1 and entity2 can low five each other
+            "high_five": DenseSelectEntityActionMask(
+                np.array([3]), np.array([0]), None
+            ),
+            "mid_five": DenseSelectEntityActionMask(np.array([1, 2]), np.array([3]), None),
+            "low_five": DenseSelectEntityActionMask(
+                np.array([0, 1, 2]), np.array([0, 1, 2]), None
+            ),
+        },
+        0.0,
+        False,
+        None,
+    )
 
-    # entity1 observations should have a ragged array with lengths [2, 1, 0]
-    # rare observations should have a ragged array with lengths [0, 0, 3]
-    assert np.all(obs_batch.entities['entity1'].size1() == [2, 1, 0])
-    assert np.all(obs_batch.entities['rare'].size1() == [0, 0, 3])
+    obs_batch = batch_obs(
+        [observation1, observation2, observation3], obs_space, action_space
+    )
+
+    assert np.all(obs_batch.action_masks["high_five"].actors.size1() == [0, 1, 1])
+    assert np.all(obs_batch.action_masks["high_five"].actees.size1() == [0, 1, 1])
+
+    assert np.all(obs_batch.action_masks["mid_five"].actors.size1() == [0, 0, 2])
+    assert np.all(obs_batch.action_masks["mid_five"].actees.size1() == [0, 0, 1])
+
+    assert np.all(obs_batch.action_masks["low_five"].actors.size1() == [2, 0, 3])
+    assert np.all(obs_batch.action_masks["low_five"].actees.size1() == [2, 0, 3])
+
 
 def test_batch_obs_categorical_action():
     """
-    We  have a set of observations and only a single one of those observations contains a paricular action and associated mask.
-    When this action is batched, it needs to needs to contain 0-length rows for that action/mask for all other observations.
+    In some cases there are categorical that may only exist for certain entity types, or may only exist under certain circumstances.
+    A particular example would be an action that is only available when an entity has a particular state (a special item or similar)
     """
 
     obs_space = ObsSpace(
@@ -188,59 +212,68 @@ def test_batch_obs_categorical_action():
         }
     )
 
+    action_space = {
+        "move": CategoricalActionSpace(["up", "down", "left", "right"]),
+        "choose_inventory_item": CategoricalActionSpace(
+            ["axe", "sword", "pigeon"]
+        ),
+    }
+
     observation1 = Observation(
         {
             "entity1": np.array([[10, 10, 10]], np.float32),
-            "entity2": np.array([[10, 10, 10]], np.float32)
+            "entity2": np.array([[10, 10, 10]], np.float32),
         },
         ["entity1_0", "entity2_0"],
         {
-            # entity1 can high five entity 2 and vice versa
-            "high-five": SelectEntityAction([("entity1_0", "entity2_0"), ("entity2_0", "entity1_0")])
+            # both entity1 and entity2 can move all directions
+            "move": DenseCategoricalActionMask(np.array([0, 1]), np.array([[True, True, True, True], [True, True, True, True]])),
         },
         0.0,
         False,
-        None
+        None,
     )
 
     observation2 = Observation(
         {
             "entity1": np.array([[10, 10, 10]], np.float32),
-            "entity2": np.array([[10, 10, 10]], np.float32)
+            "entity3": np.array([[10, 10, 10], [10, 10, 10]], np.float32),
         },
-        ["entity1_0","entity3_0"],
+        ["entity1_0", "entity3_0", "entity3_1"],
         {
-            # entity3 can high five entity 1
-            "high-five": SelectEntityAction([("entity3_0", "entity1_0")])
+            # all entities can move. Entity 3_1 can also choose items
+            "move": DenseCategoricalActionMask(np.array([0, 1, 2]), np.array([[True, True, True, True], [True, True, True, True], [True, True, True, True]])),
+            "choose_inventory_item": DenseCategoricalActionMask(np.array([2]), np.array([[True, True, True]]))
         },
         0.0,
         False,
-        None
+        None,
     )
 
-    # now we introduce the rare entity, and remove entity1
     observation3 = Observation(
         {
-            "entity1": np.array([[10, 10, 10]], np.float32),
-            "entity2": np.array([[10, 10, 10]], np.float32),
-            "entity3": np.array([[10, 10, 10]], np.float32)
+            "entity1": np.array([[10, 10, 10], [10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10], [10, 10, 10]], np.float32),
+            "entity3": np.array([[10, 10, 10], [10, 10, 10]], np.float32),
         },
-        ["entity1_0", "entity3_0"],
+        ["entity1_0", "entity1_1", "entity2_0", "entity2_1", "entity3_0", "entity3_1"],
         {
-            # entity3 can high five entity 1, and entity 2 can high five entity3. entity1 and entity2 cannot high five each other
-            "high-five": SelectEntityAction([("entity3_0", "entity1_0"), ("entity2_0", "entity3_0")])
+            # no entities can move or do anything
         },
         0.0,
         False,
-        None
+        None,
     )
 
-    obs_batch = batch_obs([observation1, observation2, observation3], obs_space)
+    obs_batch = batch_obs(
+        [observation1, observation2, observation3], obs_space, action_space
+    )
 
-    # entity1 observations should have a ragged array with lengths [2, 1, 0]
-    # rare observations should have a ragged array with lengths [0, 0, 3]
-    assert np.all(obs_batch.entities['entity1'].size1() == [2, 1, 0])
-    assert np.all(obs_batch.entities['rare'].size1() == [0, 0, 3])
+    assert np.all(obs_batch.action_masks["move"].actors.size1() == [2, 3, 0])
+    assert np.all(obs_batch.action_masks["move"].masks.size1() == [2, 3, 0])
+
+    assert np.all(obs_batch.action_masks["choose_inventory_item"].actors.size1() == [0, 1, 0])
+    assert np.all(obs_batch.action_masks["choose_inventory_item"].masks.size1() == [0, 1, 0])
 
 # def test_merge_rare_entity():
 

--- a/entity_gym/entity_gym/test_environment.py
+++ b/entity_gym/entity_gym/test_environment.py
@@ -2,7 +2,13 @@ from entity_gym.envs.cherry_pick import CherryPick
 from entity_gym.environment import EnvList, ParallelEnvList
 from entity_gym.environment import (
     SelectEntityAction,
+    Observation,
+    ObsSpace,
+    Entity,
+    batch_obs,
+    merge_obs
 )
+import numpy as np
 
 
 def test_env_list() -> None:
@@ -17,8 +23,8 @@ def test_env_list() -> None:
     assert len(obs_reset.ids) == 100
 
     actions = [
-        {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
-    ] * 100
+                  {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
+              ] * 100
     obs_act = envs.act(actions, obs_space)
 
     assert len(obs_act.ids) == 100
@@ -36,8 +42,207 @@ def test_parallel_env_list() -> None:
     assert len(obs_reset.ids) == 100
 
     actions = [
-        {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
-    ] * 100
+                  {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
+              ] * 100
     obs_act = envs.act(actions, obs_space)
 
     assert len(obs_act.ids) == 100
+
+
+def test_batch_obs_entities():
+    """
+    We  have a set of observations and only a single one of those observations contains a paricular entity.
+    When this entity is batched, it needs to needs to contain 0-length rows for that entity for all other observations.
+    """
+
+    obs_space = ObsSpace(
+        {
+            "entity1": Entity(["x", "y", "z"]),
+            "rare": Entity(["x", "y", "z", "health", "thing"]),
+        }
+    )
+
+    observation1 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10], [10, 10, 10]], np.float32)
+        },
+        ["entity1_0", "entity1_1"],
+        {},
+        0.0,
+        False,
+        None
+    )
+
+    observation2 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0"],
+        {},
+        0.0,
+        False,
+        None
+    )
+
+    # now we introduce the rare entity, and remove entity1
+    observation3 = Observation(
+        {
+            "rare": np.array([[10, 10, 10, 4, 2], [10, 10, 10, 4, 2], [10, 10, 10, 4, 2]], np.float32)
+        },
+        ["rare1_0", "rare1_1", "rare1_2"],
+        {},
+        0.0,
+        False,
+        None
+    )
+
+    obs_batch = batch_obs([observation1, observation2, observation3], obs_space)
+
+    # entity1 observations should have a ragged array with lengths [2, 1, 0]
+    # rare observations should have a ragged array with lengths [0, 0, 3]
+    assert np.all(obs_batch.entities['entity1'].size1() == [2, 1, 0])
+    assert np.all(obs_batch.entities['rare'].size1() == [0, 0, 3])
+
+
+def test_batch_obs_select_entity_action():
+    """
+    We  have a set of observations and only a single one of those observations contains a paricular action and associated mask.
+    When this action is batched, it needs to needs to contain 0-length rows for that action/mask for all other observations.
+    """
+
+    obs_space = ObsSpace(
+        {
+            "entity1": Entity(["x", "y", "z"]),
+            "entity2": Entity(["x", "y", "z"]),
+            "entity3": Entity(["x", "y", "z"]),
+        }
+    )
+
+    observation1 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0", "entity2_0"],
+        {
+            # entity1 can low five entity 2 and vice versa
+            "low-five": SelectEntityAction([("entity1_0", "entity2_0"), ("entity2_0", "entity1_0")])
+        },
+        0.0,
+        False,
+        None
+    )
+
+    observation2 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0","entity3_0"],
+        {
+            # entity3 can high five entity 1
+            "high-five": SelectEntityAction([("entity3_0", "entity1_0")])
+        },
+        0.0,
+        False,
+        None
+    )
+
+    # now we introduce the rare entity, and remove entity1
+    observation3 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10]], np.float32),
+            "entity3": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0", "entity3_0"],
+        {
+            # entity3 can high five entity 1, and entity 2 can mid five entity3. entity1 and entity2 can low five each other
+            "high-five": SelectEntityAction([("entity3_0", "entity1_0")]),
+            "mid-five": SelectEntityAction([("entity2_0", "entity3_0")]),
+            "low-five": SelectEntityAction([("entity1_0", "entity2_0"), ("entity2_0", "entity1_0")])
+        },
+        0.0,
+        False,
+        None
+    )
+
+    obs_batch = batch_obs([observation1, observation2, observation3], obs_space)
+
+    # entity1 observations should have a ragged array with lengths [2, 1, 0]
+    # rare observations should have a ragged array with lengths [0, 0, 3]
+    assert np.all(obs_batch.entities['entity1'].size1() == [2, 1, 0])
+    assert np.all(obs_batch.entities['rare'].size1() == [0, 0, 3])
+
+def test_batch_obs_categorical_action():
+    """
+    We  have a set of observations and only a single one of those observations contains a paricular action and associated mask.
+    When this action is batched, it needs to needs to contain 0-length rows for that action/mask for all other observations.
+    """
+
+    obs_space = ObsSpace(
+        {
+            "entity1": Entity(["x", "y", "z"]),
+            "entity2": Entity(["x", "y", "z"]),
+            "entity3": Entity(["x", "y", "z"]),
+        }
+    )
+
+    observation1 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0", "entity2_0"],
+        {
+            # entity1 can high five entity 2 and vice versa
+            "high-five": SelectEntityAction([("entity1_0", "entity2_0"), ("entity2_0", "entity1_0")])
+        },
+        0.0,
+        False,
+        None
+    )
+
+    observation2 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0","entity3_0"],
+        {
+            # entity3 can high five entity 1
+            "high-five": SelectEntityAction([("entity3_0", "entity1_0")])
+        },
+        0.0,
+        False,
+        None
+    )
+
+    # now we introduce the rare entity, and remove entity1
+    observation3 = Observation(
+        {
+            "entity1": np.array([[10, 10, 10]], np.float32),
+            "entity2": np.array([[10, 10, 10]], np.float32),
+            "entity3": np.array([[10, 10, 10]], np.float32)
+        },
+        ["entity1_0", "entity3_0"],
+        {
+            # entity3 can high five entity 1, and entity 2 can high five entity3. entity1 and entity2 cannot high five each other
+            "high-five": SelectEntityAction([("entity3_0", "entity1_0"), ("entity2_0", "entity3_0")])
+        },
+        0.0,
+        False,
+        None
+    )
+
+    obs_batch = batch_obs([observation1, observation2, observation3], obs_space)
+
+    # entity1 observations should have a ragged array with lengths [2, 1, 0]
+    # rare observations should have a ragged array with lengths [0, 0, 3]
+    assert np.all(obs_batch.entities['entity1'].size1() == [2, 1, 0])
+    assert np.all(obs_batch.entities['rare'].size1() == [0, 0, 3])
+
+# def test_merge_rare_entity():
+
+
+# def test_merge_rare_action():

--- a/entity_gym/pyproject.toml
+++ b/entity_gym/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 ragged-buffer = "^0.2.10"
+cloudpickle = "^2.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/entity_gym/pyproject.toml
+++ b/entity_gym/pyproject.toml
@@ -7,7 +7,8 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 ragged-buffer = "^0.2.10"
-cloudpickle = "^2.0.0"
+msgpack = "^1.0.3"
+msgpack-numpy = "^0.4.7"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/entity_gym/pyproject.toml
+++ b/entity_gym/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-ragged-buffer = "^0.2.10"
+ragged-buffer = "^0.2.11"
 msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,3 +21,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-griddly.*]
 ignore_missing_imports = True
+[mypy-cloudpickle.*]
+ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -167,6 +167,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
+cloudpickle = "^2.0.0"
 enn_zoo = {path = "../enn_zoo", develop = true}
 entity_gym = {path = "../entity_gym", develop = true}
 msgpack = "^1.0.3"
@@ -210,6 +211,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
+cloudpickle = "^2.0.0"
 ragged-buffer = "^0.2.10"
 
 [package.source]
@@ -275,7 +277,7 @@ tool = ["click (>=6.0.0)"]
 
 [[package]]
 name = "griddly"
-version = "1.2.21"
+version = "1.2.23"
 description = "Griddly Python Libraries"
 category = "main"
 optional = false
@@ -843,7 +845,7 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.5.0"
+version = "1.5.1"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -1204,15 +1206,15 @@ google-auth-oauthlib = [
     {file = "google_auth_oauthlib-0.4.6-py2.py3-none-any.whl", hash = "sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73"},
 ]
 griddly = [
-    {file = "griddly-1.2.21-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:b655da94ab46e9aacacd2ac8ac8e0c7a489281e310733bc501e2d7bc20341122"},
-    {file = "griddly-1.2.21-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:a8b2bd42e6d973968d6b0560a39facf3f375d11a6c20d113615a63e6642b8b5a"},
-    {file = "griddly-1.2.21-cp37-cp37m-win_amd64.whl", hash = "sha256:e831c6f4f5a73b33dae2d78820c0c13d909f30c029f72b58663e0ed983e70765"},
-    {file = "griddly-1.2.21-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:c998cb1c8f985f9c7de0a25d42311b90e046c857bf47370691bb082295051b0b"},
-    {file = "griddly-1.2.21-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:34d33ae01c4737e5fa8400b747a21a76d81f4dfa380d5e90a6ae3b21d63d2a12"},
-    {file = "griddly-1.2.21-cp38-cp38-win_amd64.whl", hash = "sha256:c002ecd05443255ad29c2c14692beff6e596d1a5d44dd54c22dc71084bf613b8"},
-    {file = "griddly-1.2.21-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:b17621fb3803918466fd13189f79a44cdb9d674357fbf54b7a554ea0843776db"},
-    {file = "griddly-1.2.21-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:600f441279bec91af16cbcfec8e1ab52b0195d7f24235281e8dab095a6bfe4e3"},
-    {file = "griddly-1.2.21-cp39-cp39-win_amd64.whl", hash = "sha256:e2d4b86ce2c41f5afa2b05891e7504198657899e165a1e14f330f357a896cb73"},
+    {file = "griddly-1.2.23-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:1afbab7b9d7491553afbc93b47bc5fbe2add9e29f8fe3cd1e02b541e01662618"},
+    {file = "griddly-1.2.23-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:51bcd87dfcef20a37a6f367d41d17d425b13863e0195b0ac357ceea044db6954"},
+    {file = "griddly-1.2.23-cp37-cp37m-win_amd64.whl", hash = "sha256:223ba9ca20c8157cf8758482ec20beb4769d9c5b07b7033d53c566794d12762d"},
+    {file = "griddly-1.2.23-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:d720e678af304e8e3a561822949841f5442a442d77651fa9234da7719e16c4cf"},
+    {file = "griddly-1.2.23-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:659f695ec11102ebd01285b393e6dca24e262f1fed83aa3c1729fa8eb30bcd4f"},
+    {file = "griddly-1.2.23-cp38-cp38-win_amd64.whl", hash = "sha256:798c5c5506f1f6a61c1bb753b349277ab432a4557802c34288ece20cddc2ec04"},
+    {file = "griddly-1.2.23-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:d7b741247f6549b2e77ced103ec09a9b215e4d97fd36128407b685781c705d3f"},
+    {file = "griddly-1.2.23-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:4fde0b7534adea749624c94de52869c36ca0cd66d50623d9e52862417a22f930"},
+    {file = "griddly-1.2.23-cp39-cp39-win_amd64.whl", hash = "sha256:a1245b06ec5a95be2dfd18d39cf85e3ced4bbd08dd04e83d866f252a030c4760"},
 ]
 grpcio = [
     {file = "grpcio-1.42.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:6e5eec67909795f7b1ff2bd941bd6c2661ca5217ea9c35003d73314100786f60"},
@@ -1657,8 +1659,8 @@ rsa = [
     {file = "rsa-4.8.tar.gz", hash = "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.5.0.tar.gz", hash = "sha256:789a11a87ca02491896e121efdd64e8fd93327b69e8f2f7d42f03e2569648e88"},
-    {file = "sentry_sdk-1.5.0-py2.py3-none-any.whl", hash = "sha256:0db297ab32e095705c20f742c3a5dac62fe15c4318681884053d0898e5abb2f6"},
+    {file = "sentry-sdk-1.5.1.tar.gz", hash = "sha256:2a1757d6611e4bec7d672c2b7ef45afef79fed201d064f53994753303944f5a8"},
+    {file = "sentry_sdk-1.5.1-py2.py3-none-any.whl", hash = "sha256:e4cb107e305b2c1b919414775fa73a9997f996447417d22b98e7610ded1e9eb5"},
 ]
 shortuuid = [
     {file = "shortuuid-1.0.8-py3-none-any.whl", hash = "sha256:44a7a86bcf24dbaba2e626cf80c779926b7c3a0d31a3a013e0d3cd1077707d23"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -167,13 +167,12 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-cloudpickle = "^2.0.0"
 enn_zoo = {path = "../enn_zoo", develop = true}
 entity_gym = {path = "../entity_gym", develop = true}
 msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 numpy = "^1.21.4"
-ragged-buffer = "^0.2.10"
+ragged-buffer = "^0.2.11"
 rogue_net = {path = "../rogue_net", develop = true}
 tensorboard = "^2.7.0"
 torch = "^1.10.0"
@@ -211,8 +210,9 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-cloudpickle = "^2.0.0"
-ragged-buffer = "^0.2.10"
+msgpack = "^1.0.3"
+msgpack-numpy = "^0.4.7"
+ragged-buffer = "^0.2.11"
 
 [package.source]
 type = "directory"
@@ -363,7 +363,7 @@ tifffile = ["tifffile"]
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.2"
+version = "4.8.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -772,7 +772,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "ragged-buffer"
-version = "0.2.10"
+version = "0.2.11"
 description = ""
 category = "main"
 optional = false
@@ -959,7 +959,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.2"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
@@ -967,7 +967,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "torch"
-version = "1.10.0"
+version = "1.10.1"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 category = "main"
 optional = false
@@ -1274,8 +1274,8 @@ imageio = [
     {file = "imageio-2.13.3.tar.gz", hash = "sha256:bb87b272e1e9b05d242e11f8d88d030aefa68ca95daf3accc986d0b782ae3cd5"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
-    {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
+    {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
+    {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1632,17 +1632,17 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 ragged-buffer = [
-    {file = "ragged_buffer-0.2.10-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:cab38efd4c5edba23626a3a38595607bfd82e85ce7556df73826d970558f46c0"},
-    {file = "ragged_buffer-0.2.10-cp310-none-win_amd64.whl", hash = "sha256:43524b1a3d90da57439fd449a85fe510f5ae300c4a320e679f2dc44b01b7d2bf"},
-    {file = "ragged_buffer-0.2.10-cp36-none-win_amd64.whl", hash = "sha256:ea13b75e12fd1079e84c06691a7966be57d0e07810c01474dff6961f35a3c664"},
-    {file = "ragged_buffer-0.2.10-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:ce5e07335bb133ddd8b6c7f60bd8eff5737e91ce58da31e9bd4b2ddca6bfa027"},
-    {file = "ragged_buffer-0.2.10-cp37-none-win_amd64.whl", hash = "sha256:5feb9d282ad4bd9599e8d71654ce1419f213006fd86291b81963b88075f6a833"},
-    {file = "ragged_buffer-0.2.10-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:93484877250abdd8d8c496e2b4b840a8d531390ed451cd512407ebb4aa8df8ce"},
-    {file = "ragged_buffer-0.2.10-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:bbc074ec1fee2a1cc0b6c8c8b351152e11e17cc1b0e6f6218d4af10bcebf04d2"},
-    {file = "ragged_buffer-0.2.10-cp38-none-win_amd64.whl", hash = "sha256:1c84ddb2e396d86c009127673926cfa764df8f58120f0b58504d27da3cae4fe2"},
-    {file = "ragged_buffer-0.2.10-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:b3e3b5b1cf8979693ce72741fcd7756df1a276adab0c6b71583e88512af71abe"},
-    {file = "ragged_buffer-0.2.10-cp39-none-win_amd64.whl", hash = "sha256:2579d231de52f3e335ec10bffaa6540889a5c4397cc77d33f28fa332dbcd69f7"},
-    {file = "ragged_buffer-0.2.10.tar.gz", hash = "sha256:699c6ce8c76f9e7153c394ad16855042c58fed6f082194110147c80cac0abbb4"},
+    {file = "ragged_buffer-0.2.11-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:475339854fa4afed3703e3e7d986705b30a8e1111b2f9b72b9d1e4b1be402206"},
+    {file = "ragged_buffer-0.2.11-cp310-none-win_amd64.whl", hash = "sha256:5eed7c9104b8f0891c9d9be2fa12fe633ded01d2e9293d4a1f9c247c61f31d52"},
+    {file = "ragged_buffer-0.2.11-cp36-none-win_amd64.whl", hash = "sha256:9433f480beebef25eda8146264278a81d596d378ddffaadba4d822241021341b"},
+    {file = "ragged_buffer-0.2.11-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:e1244c1dc089f85ec6584f55dd867c3c06ef75c3bf383cdeff5ce2e18df4f0d3"},
+    {file = "ragged_buffer-0.2.11-cp37-none-win_amd64.whl", hash = "sha256:950cbed3e2f36b0cd7ede893c60b91a6ef12d3820cdbddd83b538438cd218d0b"},
+    {file = "ragged_buffer-0.2.11-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:975715867186a4a963736d0f5031f00afa87efd80adbac4276b969620011ebb2"},
+    {file = "ragged_buffer-0.2.11-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:63268b8f988bfe9e6141697446ba8b853737a84eee68f658874151794b8c7257"},
+    {file = "ragged_buffer-0.2.11-cp38-none-win_amd64.whl", hash = "sha256:960f3f144cbabdbe033ec64ebef720d48149fe9c2d60cf3ddafe68ea442b2b38"},
+    {file = "ragged_buffer-0.2.11-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:f1d87f95d9b75de07b98ff7a684130d80f8eaffd8efa2916ca04e2275ef607ec"},
+    {file = "ragged_buffer-0.2.11-cp39-none-win_amd64.whl", hash = "sha256:0811a6e903f73c9c0c11cdc69c5bf7afc86911b74822cd10e0018ca5f34c36f4"},
+    {file = "ragged_buffer-0.2.11.tar.gz", hash = "sha256:8e04ea195356ab3ed8ed759a22f343830047d3d3f04dc7e2d56b9349983c49b5"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -1698,28 +1698,28 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
-    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 torch = [
-    {file = "torch-1.10.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:56022b0ce94c54e95a2f63fc5a1494feb1fc3d5c7a9b35a62944651d03edef05"},
-    {file = "torch-1.10.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:13e1ffab502aa32d6841a018771b47028d02dbbc685c5b79cfd61db5464dae4e"},
-    {file = "torch-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3c0a942e0df104c80b0eedc30d2a19cdc3d28601bc6e280bf24b2e6255016d3b"},
-    {file = "torch-1.10.0-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:eea16c01af1980ba709c00e8d5e6c09bedb5b30f9fa2085f6a52a78d7dc4e125"},
-    {file = "torch-1.10.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:b812e8d40d7037748da40bb695bd849e7b2e7faad4cd06df53d2cc4531926fda"},
-    {file = "torch-1.10.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:034df0b20603bfc81325094586647302891b9b20be7e36f152c7dd6af00deac1"},
-    {file = "torch-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:67fc509e207b8e7330f2e76e77800950317d31d035a4d19593db991962afead4"},
-    {file = "torch-1.10.0-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:4499055547087d7ef7e8a754f09c2c4f1470297ae3e5490363dba66c75501b21"},
-    {file = "torch-1.10.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ab0cf330714c8f79a837c04784a7a5658b014cf5a4ca527e7b710155ae519cdf"},
-    {file = "torch-1.10.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e01ba5946267014abfdb30248bcdbd457aaa20cff749febe7fc191e5ae096af4"},
-    {file = "torch-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:9013002adcb42bac05dcdbf0a03dd9f6bb5d7ab8b9817041c1176a014870786b"},
-    {file = "torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:aef7afb62e9b174b4e0e5e1e4a42e3bab3b8490a668d666f62f7d4517559fbf2"},
-    {file = "torch-1.10.0-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:d6185827b285780653cdd81d77a09fdca76a5b190d5986d552be2a5c442cfaa4"},
-    {file = "torch-1.10.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d82e68302c9b5c76ed585e04d61be0ca2184f70cb8ffeba8610570609ad5d7c9"},
-    {file = "torch-1.10.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:e5822200bf80a1495ad98a2bb41803eeba4a85ce373e35fc65765f7f888f5374"},
-    {file = "torch-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:ca2c88fa4376e2648785029ab108e6e7abd784eb6535fc6036004b9254f9f7c1"},
-    {file = "torch-1.10.0-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:d6ef87470b44df9970e84542547d5ba7720bb89616602441df555a39b124e2bc"},
-    {file = "torch-1.10.0-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:eea675ec01ec4b4a0655fd2984f166a5ca3b933dae6ad4eb4e52eba7026dc176"},
+    {file = "torch-1.10.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:adbb5f292e260e39715d67478823e03e3001db1af5b02c18caa34549dccb421e"},
+    {file = "torch-1.10.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:ac8cae04458cc47555fa07a760496c2fdf687223bcc13df5fed56ea3aead37f5"},
+    {file = "torch-1.10.1-cp36-cp36m-win_amd64.whl", hash = "sha256:40508d67288c46ff1fad301fa6e996e0e936a733f2401475fc92c21dc3ef702d"},
+    {file = "torch-1.10.1-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:8b47bd113c6cbd9a49669aaaa233ad5f25852d6ca3e640f9c71c808e65a1fdf4"},
+    {file = "torch-1.10.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:50360868ad3f039cf99f0250300dbec51bf686a7b84dc6bbdb8dff4b1171c0f0"},
+    {file = "torch-1.10.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e3d2154722189ed74747a494dce9588978dd55e43ca24c5bd307fb52620b232b"},
+    {file = "torch-1.10.1-cp37-cp37m-win_amd64.whl", hash = "sha256:d9c495bcd5f00becff5b051b5e4be86b7eaa0433cd0fe57f77c02bc1b93ab5b1"},
+    {file = "torch-1.10.1-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:6b327d7b4eb2461b16d46763d46df71e597235ccc428650538a2735a0898270d"},
+    {file = "torch-1.10.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1c6c56178e5dacf7602ad00dc79c263d6c41c0f76261e9641e6bd2679678ceb3"},
+    {file = "torch-1.10.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2ffa2db4ccb6466c59e3f95b7a582d47ae721e476468f4ffbcaa2832e0b92b9b"},
+    {file = "torch-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:af577602e884c5e40fbd29ec978f052202355da93cd31e0a23251bd7aaff5a99"},
+    {file = "torch-1.10.1-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:725d86e9809073eef868a3ddf4189878ee7af46fac71403834dd0925b3db9b82"},
+    {file = "torch-1.10.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:fa197cfe047d0515bef238f42472721406609ebaceff2fd4e17f2ad4692ee51c"},
+    {file = "torch-1.10.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cca660b27a90dbbc0af06c859260f6b875aef37c0897bd353e5deed085d2c877"},
+    {file = "torch-1.10.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:01f4ffdafbfbd7d106fb4e487feee2cf29cced9903df8cb0444b0e308f9c5e92"},
+    {file = "torch-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:607eccb7d539a11877cd02d95f4b164b7941fcf538ac7ff087bfed19e3644283"},
+    {file = "torch-1.10.1-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:26b6dfbe21e247e67c615bfab0017ec391ed1517f88bbeea6228a49edd24cd88"},
+    {file = "torch-1.10.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:5644280d88c5b6de27eacc0d911f968aad41a4bab297af4df5e571bc0927d3e4"},
 ]
 torch-scatter = [
     {file = "torch_scatter-2.0.9.tar.gz", hash = "sha256:08f5511d64473badf0a71d156b36dc2b09b9c2f00a7cd373b935b490c477a7f1"},

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -55,7 +55,7 @@ class CategoricalActionHead(nn.Module):
         logits = self.proj(actor_embeds)
 
         # Apply masks from the environment
-        if mask.masks is not None:
+        if mask.masks is not None and mask.masks.size0() > 0:
             reshaped_masks = torch.tensor(
                 mask.masks.as_array().reshape(logits.shape)
             ).to(x.data.device)


### PR DESCRIPTION
Taking inspiration from stable-baselines' vector implementation, but with some additional optimizations... the ParallelListEnv takes a `num_processes` and `num_envs` parameter. and will split the envs into equal proportions on each process.

This is better than having a process per-environment as it reduces the latency/observations ratio. (having 10 environments per process, means we can get 10 observations with only 1 send/receive from the process).

Setting `num_processes==num_envs` is equivalent to SubProcVecEnv. This has a overhead of 1 observation per send/receive.

Setting `num_processes==1` means you have no parallelization.

Setting `num_processes==8` and `num_envs=64` will give you 8 envs per-process. This has a reduced overhead of 8 observations per send/recieve.

With Griddly I can achieve about 6K SPS, up from previous 3K SPS, when the envs are split across 8 processes.
![image](https://user-images.githubusercontent.com/1370765/146036471-3e7d24dd-6151-468e-8a55-43bf2a8eed9e.png)
