### PR TITLE
 Implement relative positional encoding

### DIFF
--- a/enn_ppo/enn_ppo/simple_trace.py
+++ b/enn_ppo/enn_ppo/simple_trace.py
@@ -6,17 +6,18 @@ from contextlib import contextmanager
 
 
 class Tracer:
-    def __init__(self) -> None:
+    def __init__(self, cuda: bool = torch.cuda.is_available()) -> None:
         self.start_time: List[float] = []
         self.callstack: List[str] = []
         self.total_time: DefaultDict[str, float] = defaultdict(float)
+        self.cuda = cuda
 
     def start(self, name: str) -> None:
         self.callstack.append(name)
         self.start_time.append(time.time())
 
     def end(self, name: str) -> None:
-        if torch.cuda.is_available():
+        if self.cuda:
             torch.cuda.synchronize()
         self.total_time[self.stack] += time.time() - self.start_time.pop()
         actual_name = self.callstack.pop()

--- a/enn_ppo/enn_ppo/test_training.py
+++ b/enn_ppo/enn_ppo/test_training.py
@@ -125,17 +125,17 @@ def test_relpos_encoding() -> None:
     args = train.parse_args(
         [
             "--gym-id=FloorIsLava",
-            "--total-timesteps=5000",
+            "--total-timesteps=10000",
             "--num-envs=64",
             "--processes=1",
             "--d-model=16",
             "--n-layer=2",
             "--num-steps=2",
             "--num-minibatches=4",
-            "--ent-coef=0.3",
+            "--ent-coef=0.4",
             "--anneal-entropy",
             "--cuda=False",
-            "--learning-rate=0.01",
+            "--learning-rate=0.02",
             '--relpos-encoding={"extent": [1, 1], "position_features": ["x", "y"], "per_entity_values": true}',
         ]
     )

--- a/enn_ppo/enn_ppo/test_training.py
+++ b/enn_ppo/enn_ppo/test_training.py
@@ -148,3 +148,28 @@ def test_relpos_encoding() -> None:
     meanrew = train.train(args)
     print(f"Final mean reward: {meanrew}")
     assert meanrew < 0.2
+
+
+def test_asymetric_relpos_encoding() -> None:
+    # poetry run python enn_ppo/enn_ppo/train.py --gym-id=FloorIsLava --total-timesteps=5000 --num-envs=64 --processes=1 --d-model=16 --n-layer=2 --num-steps=2 --num-minibatches=4 --ent-coef=0.3 --anneal-entropy --cuda=False --relpos-encoding='{"extent": [1, 1], "position_features": ["x", "y"]}' --learning-rate=0.01
+    args = train.parse_args(
+        [
+            "--gym-id=FloorIsLava",
+            "--total-timesteps=2000",
+            "--num-envs=64",
+            "--processes=1",
+            "--d-model=16",
+            "--n-layer=2",
+            "--num-steps=1",
+            "--num-minibatches=4",
+            "--ent-coef=0.0",
+            "--anneal-entropy",
+            "--cuda=False",
+            "--learning-rate=0.02",
+            '--relpos-encoding={"extent": [5, 1], "position_features": ["x", "y"], "per_entity_values": true}',
+        ]
+    )
+
+    meanrew = train.train(args)
+    print(f"Final mean reward: {meanrew}")
+    assert meanrew >= 0.15

--- a/enn_ppo/enn_ppo/test_training.py
+++ b/enn_ppo/enn_ppo/test_training.py
@@ -118,3 +118,33 @@ def test_cherry_pick() -> None:
     )
     meanrew = train.train(args)
     print(f"Final mean reward: {meanrew}")
+
+
+def test_relpos_encoding() -> None:
+    # poetry run python enn_ppo/enn_ppo/train.py --gym-id=FloorIsLava --total-timesteps=5000 --num-envs=64 --processes=1 --d-model=16 --n-layer=2 --num-steps=2 --num-minibatches=4 --ent-coef=0.3 --anneal-entropy --cuda=False --relpos-encoding='{"extent": [1, 1], "position_features": ["x", "y"]}' --learning-rate=0.01
+    args = train.parse_args(
+        [
+            "--gym-id=FloorIsLava",
+            "--total-timesteps=5000",
+            "--num-envs=64",
+            "--processes=1",
+            "--d-model=16",
+            "--n-layer=2",
+            "--num-steps=2",
+            "--num-minibatches=4",
+            "--ent-coef=0.3",
+            "--anneal-entropy",
+            "--cuda=False",
+            "--learning-rate=0.01",
+            '--relpos-encoding={"extent": [1, 1], "position_features": ["x", "y"], "per_entity_values": true}',
+        ]
+    )
+
+    meanrew = train.train(args)
+    print(f"Final mean reward: {meanrew}")
+    assert meanrew >= 0.99
+
+    args.relpos_encoding = None
+    meanrew = train.train(args)
+    print(f"Final mean reward: {meanrew}")
+    assert meanrew < 0.2

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -39,6 +39,7 @@ from entity_gym.envs import ENV_REGISTRY
 from enn_zoo.griddly import GRIDDLY_ENVS, create_env
 from enn_ppo.sample_recorder import SampleRecorder
 from enn_ppo.simple_trace import Tracer
+from rogue_net.relpos_encoding import RelposEncodingConfig
 from rogue_net.actor import AutoActor
 from rogue_net import head_creator
 from rogue_net.translate_positions import TranslatePositions
@@ -88,6 +89,8 @@ def parse_args(override_args: Optional[List[str]] = None) -> argparse.Namespace:
     # Network architecture
     parser.add_argument('--d-model', type=int, default=64,
         help='the hidden size of the network layers')
+    parser.add_argument('--n-head', type=int, default=1,
+        help='the number of attention heads')
     parser.add_argument('--d-qk', type=int, default=64,
         help='the size queries and keys in action heads')
     parser.add_argument('--n-layer', type=int, default=1,
@@ -96,7 +99,8 @@ def parse_args(override_args: Optional[List[str]] = None) -> argparse.Namespace:
         help='if set, use pooling op instead of multi-head attention. Options: mean, max, meanmax')
     parser.add_argument('--translate', type=str, default=None,
         help='if set, translate positions to be centered on a given entity. Example: --translate=\'{"reference_entity": "SnakeHead", "position_features": ["x", "y"]}\'')
-
+    parser.add_argument('--relpos-encoding', type=str, default=None,
+        help='configuration for relative positional encoding. Example: --relpos-encoding=\'{"extent": [10, 10], "position_features": ["x", "y"]}\'')
 
     # Algorithm specific arguments
     parser.add_argument('--num-envs', type=int, default=4,
@@ -204,10 +208,12 @@ class PPOActor(AutoActor):
         obs_space: ObsSpace,
         action_space: Dict[str, ActionSpace],
         d_model: int = 64,
+        n_head: int = 1,
         d_qk: int = 16,
         n_layer: int = 1,
         pooling_op: Optional[str] = None,
         feature_transforms: Optional[TranslatePositions] = None,
+        relpos_encoding: Optional[RelposEncodingConfig] = None,
     ):
         auxiliary_heads = nn.ModuleDict(
             {"value": head_creator.create_value_head(d_model)}
@@ -216,11 +222,13 @@ class PPOActor(AutoActor):
             obs_space,
             action_space,
             d_model,
+            n_head,
             d_qk,
             auxiliary_heads,
             n_layer=n_layer,
             pooling_op=pooling_op,
             feature_transforms=feature_transforms,
+            relpos_encoding=relpos_encoding,
         )
 
     def get_value(
@@ -298,14 +306,24 @@ def train(args: argparse.Namespace) -> float:
         )
     else:
         translate = None
+    if args.relpos_encoding:
+        relpos_encoding: Optional[RelposEncodingConfig] = RelposEncodingConfig(
+            d_head=args.d_model // args.n_head,
+            obs_space=obs_space,
+            **json.loads(args.relpos_encoding),
+        )
+    else:
+        relpos_encoding = None
 
     agent = PPOActor(
         obs_space,
         action_space,
         d_model=args.d_model,
+        n_head=args.n_head,
         n_layer=args.n_layer,
         pooling_op=args.pooling_op,
         feature_transforms=translate,
+        relpos_encoding=relpos_encoding,
     ).to(device)
     optimizer = optim.Adam(agent.parameters(), lr=args.learning_rate, eps=1e-5)
     if args.track:
@@ -318,7 +336,6 @@ def train(args: argparse.Namespace) -> float:
     episodes = list(range(args.num_envs))
     curr_step = [0] * args.num_envs
     next_episode = args.num_envs
-    last_log_step = 0
 
     # TRY NOT TO MODIFY: start the game
     global_step = 0

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -269,15 +269,15 @@ def train(args: argparse.Namespace) -> float:
         % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
     )
 
-    tracer = Tracer()
-
     # TRY NOT TO MODIFY: seeding
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
     torch.backends.cudnn.deterministic = args.torch_deterministic
 
-    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+    cuda = torch.cuda.is_available() and args.cuda
+    device = torch.device("cuda" if cuda else "cpu")
+    tracer = Tracer(cuda=cuda)
 
     if args.gym_id in ENV_REGISTRY:
         env_cls = ENV_REGISTRY[args.gym_id]

--- a/entity_gym/entity_gym/envs/__init__.py
+++ b/entity_gym/entity_gym/envs/__init__.py
@@ -1,6 +1,6 @@
 from typing import Dict, Type
 from entity_gym.environment import Environment
-
+from entity_gym.envs.floor_is_lava import FloorIsLava
 from entity_gym.envs.move_to_origin import MoveToOrigin
 from entity_gym.envs.cherry_pick import CherryPick
 from entity_gym.envs.pick_matching_balls import PickMatchingBalls
@@ -21,4 +21,5 @@ ENV_REGISTRY: Dict[str, Type[Environment]] = {
     "NotHotdog": NotHotdog,
     "Xor": Xor,
     "Count": Count,
+    "FloorIsLava": FloorIsLava,
 }

--- a/entity_gym/entity_gym/envs/floor_is_lava.py
+++ b/entity_gym/entity_gym/envs/floor_is_lava.py
@@ -57,13 +57,13 @@ class FloorIsLava(Environment):
         x = random.randint(-width, width)
         y = random.randint(-width, width)
         self.player = Player(x, y)
-        self.lava = [
+        self.lava = random.sample([
             Lava(x + i, y + j)
             for i in range(-1, 2)
             for j in range(-1, 2)
             if not (i == 0 and j == 0)
-        ]
-        safe = random.randint(0, 7)
+        ], random.randint(1, 8))
+        safe = random.randint(0, len(self.lava) - 1)
         self.high_ground = HighGround(self.lava[safe].x, self.lava[safe].y)
         self.lava.pop(safe)
         obs = self.observe(obs_space)

--- a/entity_gym/entity_gym/envs/floor_is_lava.py
+++ b/entity_gym/entity_gym/envs/floor_is_lava.py
@@ -57,12 +57,15 @@ class FloorIsLava(Environment):
         x = random.randint(-width, width)
         y = random.randint(-width, width)
         self.player = Player(x, y)
-        self.lava = random.sample([
-            Lava(x + i, y + j)
-            for i in range(-1, 2)
-            for j in range(-1, 2)
-            if not (i == 0 and j == 0)
-        ], random.randint(1, 8))
+        self.lava = random.sample(
+            [
+                Lava(x + i, y + j)
+                for i in range(-1, 2)
+                for j in range(-1, 2)
+                if not (i == 0 and j == 0)
+            ],
+            random.randint(1, 8),
+        )
         safe = random.randint(0, len(self.lava) - 1)
         self.high_ground = HighGround(self.lava[safe].x, self.lava[safe].y)
         self.lava.pop(safe)

--- a/entity_gym/entity_gym/envs/floor_is_lava.py
+++ b/entity_gym/entity_gym/envs/floor_is_lava.py
@@ -1,0 +1,132 @@
+from dataclasses import dataclass
+import numpy as np
+import random
+from typing import Dict, Mapping
+
+from entity_gym.environment import (
+    CategoricalAction,
+    DenseCategoricalActionMask,
+    Environment,
+    CategoricalActionSpace,
+    ActionSpace,
+    EpisodeStats,
+    ObsSpace,
+    Observation,
+    Action,
+)
+from entity_gym.dataclass_utils import obs_space_from_dataclasses, extract_features
+
+
+@dataclass
+class Lava:
+    x: float
+    y: float
+
+
+@dataclass
+class HighGround:
+    x: float
+    y: float
+
+
+@dataclass
+class Player:
+    x: float
+    y: float
+
+
+class FloorIsLava(Environment):
+    """
+    The player is surrounded by 8 tiles, 7 of which are lava and 1 of which is high ground.
+    The player must move to one of the tiles.
+    The player receives a reward of 1 if they move to the high ground, and 0 otherwise.
+    """
+
+    @classmethod
+    def obs_space(cls) -> ObsSpace:
+        return obs_space_from_dataclasses(Lava, HighGround, Player)
+
+    @classmethod
+    def action_space(cls) -> Dict[str, ActionSpace]:
+        return {
+            "move": CategoricalActionSpace(["n", "ne", "e", "se", "s", "sw", "w", "nw"])
+        }
+
+    def reset(self, obs_space: ObsSpace) -> Observation:
+        width = 1000
+        x = random.randint(-width, width)
+        y = random.randint(-width, width)
+        self.player = Player(x, y)
+        self.lava = [
+            Lava(x + i, y + j)
+            for i in range(-1, 2)
+            for j in range(-1, 2)
+            if not (i == 0 and j == 0)
+        ]
+        safe = random.randint(0, 7)
+        self.high_ground = HighGround(self.lava[safe].x, self.lava[safe].y)
+        self.lava.pop(safe)
+        obs = self.observe(obs_space)
+        return obs
+
+    def _reset(self) -> Observation:
+        return self.reset(FloorIsLava.obs_space())
+
+    def act(self, action: Mapping[str, Action], obs_filter: ObsSpace) -> Observation:
+        for action_name, a in action.items():
+            assert isinstance(a, CategoricalAction) and action_name == "move"
+            if a.actions[0][1] == 0:
+                self.player.y += 1
+            elif a.actions[0][1] == 1:
+                self.player.y += 1
+                self.player.x += 1
+            elif a.actions[0][1] == 2:
+                self.player.x += 1
+            elif a.actions[0][1] == 3:
+                self.player.y -= 1
+                self.player.x += 1
+            elif a.actions[0][1] == 4:
+                self.player.y -= 1
+            elif a.actions[0][1] == 5:
+                self.player.y -= 1
+                self.player.x -= 1
+            elif a.actions[0][1] == 6:
+                self.player.x -= 1
+            elif a.actions[0][1] == 7:
+                self.player.y += 1
+                self.player.x -= 1
+        obs = self.observe(obs_filter, done=True)
+        return obs
+
+    def _act(self, action: Mapping[str, Action]) -> Observation:
+        return self.act(
+            action,
+            FloorIsLava.obs_space(),
+        )
+
+    def observe(self, obs_filter: ObsSpace, done: bool = False) -> Observation:
+        if (
+            done
+            and self.player.x == self.high_ground.x
+            and self.player.y == self.high_ground.y
+        ):
+            reward = 1.0
+        else:
+            reward = 0.0
+        return Observation(
+            entities=extract_features(
+                {
+                    "Player": [self.player],
+                    "Lava": self.lava,
+                    "HighGround": [self.high_ground],
+                },
+                obs_filter,
+            ),
+            action_masks={
+                "move": DenseCategoricalActionMask(actors=np.array([0]), mask=None),
+            },
+            ids=list(range(3)),
+            reward=reward,
+            done=done,
+            end_of_episode_info=EpisodeStats(1, reward) if done else None,
+        )

--- a/rogue_net/rogue_net/relpos_encoding.py
+++ b/rogue_net/rogue_net/relpos_encoding.py
@@ -1,0 +1,112 @@
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Tuple
+import torch.nn as nn
+import torch
+from ragged_buffer import RaggedBufferI64
+
+from entity_gym.environment import ObsSpace
+
+
+@dataclass(frozen=True)
+class RelposEncodingConfig:
+    extent: List[int]
+    position_features: List[str]
+    obs_space: ObsSpace
+    d_head: int
+    per_entity_values: bool = True
+
+    def __post_init__(self) -> None:
+        assert len(self.extent) == len(self.position_features)
+
+
+class RelposEncoding(nn.Module):
+    def __init__(
+        self,
+        config: RelposEncodingConfig,
+    ) -> None:
+        super().__init__()
+        self.d_head = config.d_head
+        self.position_extent = config.extent
+        self.positional_features = config.position_features
+        self.n_entity = len(config.obs_space.entities)
+        self.per_entity_values = config.per_entity_values
+        strides = []
+        positions = 1
+        for extent in self.position_extent:
+            strides.append(float(positions))
+            positions *= 2 * extent + 1
+        self.positions = positions
+        self.strides = torch.tensor(strides).unsqueeze(0)
+        # TODO: tune embedding init scale
+        self.keys = nn.Embedding(self.positions, self.d_head)
+        self.values = nn.Embedding(
+            self.positions * self.n_entity
+            if config.per_entity_values
+            else self.positions,
+            self.d_head,
+        )
+        self.keys.weight.data.normal_(mean=0.0, std=0.05)
+        self.values.weight.data.normal_(mean=0.0, std=0.2)
+        self.position_feature_indices = {
+            entity_name: torch.LongTensor(
+                [
+                    entity.features.index(feature_name)
+                    for feature_name in config.position_features
+                ]
+            )
+            for entity_name, entity in config.obs_space.entities.items()
+        }
+
+    def keys_values(
+        self,
+        # Dict from entity name to raw input features
+        x: Mapping[str, torch.Tensor],
+        # Maps entities ordered first by type to entities ordered first by frame
+        index_map: torch.Tensor,
+        # Maps flattened embeddings to packed/padded tensor with fixed sequence lengths
+        packpad_index: Optional[torch.Tensor],
+        # Ragged shape of the flattened embeddings tensor
+        shape: RaggedBufferI64,
+        # Type of each entity
+        entity_type: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        positions = []
+        for entity_name, features in x.items():
+            positions.append(features[:, self.position_feature_indices[entity_name]])
+        # Flat tensor of positions
+        tpos = torch.cat(positions, dim=0)
+        # Flat tensor of positions ordered by sample
+        tpos = tpos[index_map]
+        # Padded/packed Batch x Seq x Pos tensor of positions
+        if packpad_index is not None:
+            tpos = tpos[packpad_index]
+            entity_type = entity_type[packpad_index]
+        else:
+            tpos = tpos.reshape(shape.size0(), shape.size1(0), -1)
+            entity_type = entity_type.reshape(shape.size0(), shape.size1(0), 1)
+
+        # Batch x Seq x Seq x Pos relative positions
+        relative_positions = tpos.unsqueeze(1) - tpos.unsqueeze(2)
+
+        # TODO: different position extents on each dimension
+        clamped_positions = relative_positions.clamp(
+            min=-self.position_extent[0], max=self.position_extent[0]
+        )
+        positive_positions = clamped_positions + self.position_extent[0]
+        # TODO: only send to device once
+        indices = (
+            (positive_positions * self.strides.to(index_map.device)).sum(dim=-1).long()
+        )
+
+        # Batch x Seq x Seq x d_model
+        keys = self.keys(indices)
+
+        if self.per_entity_values:
+            per_entity_type_indices = indices + (
+                entity_type * self.positions
+            ).transpose(2, 1).long().repeat(1, indices.size(2), 1)
+        else:
+            per_entity_type_indices = indices
+        values = self.values(per_entity_type_indices)
+
+        return keys, values

--- a/rogue_net/rogue_net/transformer.py
+++ b/rogue_net/rogue_net/transformer.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Literal, Optional, Union
+from typing import Dict, Literal, Mapping, Optional, Tuple, Union
 import math
 from numpy import dtype
 from ragged_buffer import RaggedBufferI64
@@ -10,6 +10,7 @@ import torch_scatter
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
+from rogue_net.relpos_encoding import RelposEncoding, RelposEncodingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +21,10 @@ class TransformerConfig:
     resid_pdrop: float = 0.0
     attn_pdrop: float = 0.0
     n_layer: int = 1
-    n_head: int = 1
+    n_head: int = 2
     d_model: int = 64
     pooling: Optional[Literal["mean", "max", "meanmax"]] = None
+    relpos_encoding: Optional[RelposEncodingConfig] = None
 
 
 class Pool(nn.Module):
@@ -87,12 +89,17 @@ class RaggedAttention(nn.Module):
         self.n_head = config.n_head
 
     def forward(
-        self, x: torch.Tensor, batch_index: torch.Tensor, shape: RaggedBufferI64
+        self,
+        x: torch.Tensor,
+        batch_index: torch.Tensor,
+        shape: RaggedBufferI64,
+        relkeysvals: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
     ) -> torch.Tensor:
         # For more details on the implementation, see: https://github.com/entity-neural-network/incubator/pull/119
         device = x.device
         padpack = shape.padpack()
 
+        # TODO: only compute indices once
         if padpack is None:
             x = x.reshape(shape.size0(), shape.size1(0), -1)
             attn_mask = None
@@ -123,11 +130,29 @@ class RaggedAttention(nn.Module):
 
         # full self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+
+        # Relative positional encoding (keys)
+        if relkeysvals is not None:
+            relkeys = relkeysvals[0]  #       (B, T, T, hs)
+            # Broadcast and sum over last dimension (dot product of queries with relative keys)
+            # TODO: check
+            relatt = torch.einsum("bhsd,bstd->bhst", q, relkeys) * (
+                1.0 / math.sqrt(k.size(-1))
+            )  # (B, nh, T, T)
+            att += relatt
+
         if attn_mask is not None:
             att = att.masked_fill(attn_mask, -1e9)
         att = F.softmax(att, dim=-1)
         att = self.attn_drop(att)
         y = att @ v  # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+
+        # Relative positional encoding (values)
+        if relkeysvals is not None:
+            relvals = relkeysvals[1]  #       (B, T_query, T_target, hs)
+            rely = torch.einsum("bhst,bstd->bhsd", att, relvals)  # (B, nh, T, T)
+            y += rely
+
         y = (
             y.transpose(1, 2).contiguous().view(B, T, C)
         )  # re-assemble all head outputs side by side
@@ -157,9 +182,13 @@ class Block(nn.Module):
         )
 
     def forward(
-        self, x: torch.Tensor, batch_index: torch.Tensor, shape: RaggedBufferI64
+        self,
+        x: torch.Tensor,
+        batch_index: torch.Tensor,
+        shape: RaggedBufferI64,
+        relkeysvals: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = None,
     ) -> torch.Tensor:
-        x = x + self.attn(self.ln1(x), batch_index, shape)
+        x = x + self.attn(self.ln1(x), batch_index, shape, relkeysvals)
         x = x + self.mlp(self.ln2(x))
         return x
 
@@ -170,6 +199,12 @@ class Transformer(nn.Module):
 
         self.drop = nn.Dropout(config.embd_pdrop)
         self.blocks = nn.Sequential(*[Block(config) for _ in range(config.n_layer)])
+        if config.relpos_encoding is not None:
+            self.relpos_encoding: Optional[RelposEncoding] = RelposEncoding(
+                config.relpos_encoding
+            )
+        else:
+            self.relpos_encoding = None
 
         self.apply(self._init_weights)
 
@@ -187,9 +222,33 @@ class Transformer(nn.Module):
             module.weight.data.fill_(1.0)
 
     def forward(
-        self, x: torch.Tensor, batch_index: torch.Tensor, shape: RaggedBufferI64
+        self,
+        x: torch.Tensor,
+        batch_index: torch.Tensor,
+        shape: RaggedBufferI64,
+        input_feats: Mapping[str, torch.Tensor],
+        index_map: torch.Tensor,
+        entity_type: torch.Tensor,
     ) -> torch.Tensor:
         x = self.drop(x)
+
+        if self.relpos_encoding is not None:
+            device = x.device
+            padpack = shape.padpack()
+            if padpack is None:
+                tpadpack_index = None
+            else:
+                tpadpack_index = torch.LongTensor(padpack[0]).to(device)
+            relkeysvals = self.relpos_encoding.keys_values(
+                input_feats,
+                index_map,
+                tpadpack_index,
+                shape,
+                entity_type,
+            )
+        else:
+            relkeysvals = None
+
         for block in self.blocks:
-            x = block(x, batch_index, shape)
+            x = block(x, batch_index, shape, relkeysvals)
         return x

--- a/rogue_net/rogue_net/transformer.py
+++ b/rogue_net/rogue_net/transformer.py
@@ -239,7 +239,9 @@ class Transformer(nn.Module):
                 tpadpack_index = None
             else:
                 tpadpack_index = torch.LongTensor(padpack[0]).to(device)
-            relkeysvals = self.relpos_encoding.keys_values(
+            relkeysvals: Optional[
+                Tuple[torch.Tensor, torch.Tensor]
+            ] = self.relpos_encoding.keys_values(
                 input_feats,
                 index_map,
                 tpadpack_index,

--- a/rogue_net/rogue_net/translate_positions.py
+++ b/rogue_net/rogue_net/translate_positions.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Mapping
 from entity_gym.environment import ObsSpace
 from ragged_buffer import RaggedBufferF32
-import torch
 
 
 class TranslatePositions:


### PR DESCRIPTION
Implements a version of relative positional encoding for n-dimensional grids. Relative positional encoding with e.g. a 11 x 13 extent for an environment with a 2d grid can be enabled by passing `--relpos-encoding='{"extent": [5, 6], "position_features": ["x", "y"], "per_entity_values": true}'` to `enn_ppo/train.py`.

There are many variations and refinements of relative positional encoding. This implementation mostly follows the original formulation described in [Shaw et al (2018)](https://arxiv.org/abs/1803.02155). In particular, here is a non-exhaustive list of somewhat arbitrary design choices that we may want to revisit once we have some good benchmarks to test against:

- There are relative positional keys and values, but no queries.
- Keys and values are shared across all layers and heads.
- We initialize values ~ Normal(0, 0.2) and keys ~ Normal(0, 0.05).
- By default, values are different per entity type (this turns out to be quite important).
- Relative positional keys/values have the same dimension as the heads.
- All dimensions are combined, so every combination of x/y/z/... positions within the extent gets its own key/value embedding. We could also have separate keys/values for each dimension, which would reduce the total number of embeddings and might be preferable in some cases.

The current implementation requires ds^2 memory, where d is the dimension of heads and s is the sequence length. Since our sequences are relatively short so far, this does present a major issue. The usual trick used to reduce memory usage by a factor of s only works for sequences and not our more general version where entities can be at arbitrary grid points. We could still achieve the same savings with a custom GPU kernel though.