### PR TITLE
Refactor sample recorder

### DIFF
--- a/enn_ppo/enn_ppo/hypertuna.py
+++ b/enn_ppo/enn_ppo/hypertuna.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
-import datetime
 from distutils.util import strtobool
 import argparse
 import optuna

--- a/enn_ppo/enn_ppo/test_sample_recorder.py
+++ b/enn_ppo/enn_ppo/test_sample_recorder.py
@@ -1,100 +1,99 @@
 import numpy as np
 import tempfile
-from enn_ppo.sample_recorder import SampleRecorder, Trace
+from enn_ppo.sample_recorder import Sample, SampleRecorder, Trace
 from entity_gym.environment import CategoricalActionMaskBatch, ObsBatch
 from numpy.lib.twodim_base import mask_indices
 from ragged_buffer import RaggedBufferF32, RaggedBufferI64
 
-"""
-class ObsBatch:
-    entities: Dict[str, RaggedBufferF32]
-    ids: List[Sequence[EntityID]]
-    action_masks: Dict[str, ActionMaskBatch]
-    reward: npt.NDArray[np.float32]
-    done: npt.NDArray[np.bool_]
-    end_of_episode_info: Dict[int, EpisodeStats]
-"""
-
 
 def test_serde_sample() -> None:
-    obs = ObsBatch(
-        entities={
-            "hero": RaggedBufferF32.from_array(
-                np.array([[[1.0, 2.0, 0.3, 100.0, 10.0]]], dtype=np.float32),
-            ),
-            "enemy": RaggedBufferF32.from_array(
-                np.array(
-                    [
-                        [
-                            [4.0, -2.0, 0.3, 100.0],
-                            [5.0, -2.0, 0.3, 100.0],
-                            [6.0, -2.0, 0.3, 100.0],
-                        ]
-                    ],
-                    dtype=np.float32,
+    sample = Sample(
+        obs=ObsBatch(
+            entities={
+                "hero": RaggedBufferF32.from_array(
+                    np.array([[[1.0, 2.0, 0.3, 100.0, 10.0]]], dtype=np.float32),
                 ),
-            ),
-            "box": RaggedBufferF32.from_array(
-                np.array(
-                    [
+                "enemy": RaggedBufferF32.from_array(
+                    np.array(
                         [
-                            [0.0, 0.0, 0.3, 100.0],
-                            [1.0, 0.0, 0.3, 100.0],
-                            [2.0, 0.0, 0.3, 100.0],
-                        ]
-                    ],
-                    dtype=np.float32,
+                            [
+                                [4.0, -2.0, 0.3, 100.0],
+                                [5.0, -2.0, 0.3, 100.0],
+                                [6.0, -2.0, 0.3, 100.0],
+                            ]
+                        ],
+                        dtype=np.float32,
+                    ),
                 ),
+                "box": RaggedBufferF32.from_array(
+                    np.array(
+                        [
+                            [
+                                [0.0, 0.0, 0.3, 100.0],
+                                [1.0, 0.0, 0.3, 100.0],
+                                [2.0, 0.0, 0.3, 100.0],
+                            ]
+                        ],
+                        dtype=np.float32,
+                    ),
+                ),
+            },
+            action_masks={
+                "move": CategoricalActionMaskBatch(
+                    actors=RaggedBufferI64.from_array(np.array([[[0]]])), masks=None
+                ),
+                "shoot": CategoricalActionMaskBatch(
+                    actors=RaggedBufferI64.from_array(np.array([[[0]]])), masks=None
+                ),
+                "explode": CategoricalActionMaskBatch(
+                    actors=RaggedBufferI64.from_array(np.array([[[4], [5], [6]]])),
+                    masks=None,
+                ),
+            },
+            reward=np.array([0.3124125987123489]),
+            ids=[[0, 1, 2, 3, 4, 5, 6]],
+            done=np.array([False]),
+            end_of_episode_info={},
+        ),
+        probs={
+            "move": RaggedBufferF32.from_array(
+                np.array([[[0.5], [0.2], [0.3], [0.0]]], dtype=np.float32)
+            ),
+            "shoot": RaggedBufferF32.from_array(
+                np.array([[[0.9], [0.1]]], dtype=np.float32)
+            ),
+            "explode": RaggedBufferF32.from_array(
+                np.array(
+                    [[[0.3], [0.7]], [[0.2], [0.8]], [[0.1], [0.9]]], dtype=np.float32
+                )
             ),
         },
-        action_masks={
-            "move": CategoricalActionMaskBatch(
-                actors=RaggedBufferI64.from_array(np.array([[[0]]])), masks=None
-            ),
-            "shoot": CategoricalActionMaskBatch(
-                actors=RaggedBufferI64.from_array(np.array([[[0]]])), masks=None
-            ),
-            "explode": CategoricalActionMaskBatch(
-                actors=RaggedBufferI64.from_array(np.array([[[4], [5], [6]]])),
-                masks=None,
-            ),
-        },
-        reward=np.array([0.3124125987123489]),
-        ids=[[0, 1, 2, 3, 4, 5, 6]],
-        done=np.array([False]),
-        end_of_episode_info={},
+        actions={},
+        step=[13],
+        episode=[4213],
     )
-    probabilities = (
-        {
-            "move": np.array([[0.5, 0.2, 0.3, 0.0]]),
-            "shoot": np.array([[0.9, 0.1]]),
-            "explode": np.array([[0.3, 0.7], [0.2, 0.8], [0.1, 0.9]]),
-        },
-    )
-    step = [13]
-    episode = [4213]
 
     with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
         sample_recorder = SampleRecorder(f.name, act_space=None, obs_space=None)  # type: ignore
-        sample_recorder.record(obs, step, episode)
+        sample_recorder.record(sample)
         # modify the sample
-        obs.reward = np.array([1.0])
-        obs.entities["hero"] = RaggedBufferF32.from_array(
+        sample.obs.reward = np.array([1.0])
+        sample.obs.entities["hero"] = RaggedBufferF32.from_array(
             np.array([[[1.0, 2.0, 0.3, 200.0, 10.0]]], dtype=np.float32),
         )
-        sample_recorder.record(obs, step, episode)
+        sample_recorder.record(sample)
         sample_recorder.close()
 
         with open(f.name, "rb") as f:
             trace = Trace.deserialize(f.read())
             assert len(trace.samples) == 2
-            assert trace.samples[0][0].reward[0] == 0.3124125987123489
-            assert trace.samples[1][0].reward[0] == 1.0
+            assert trace.samples[0].obs.reward[0] == 0.3124125987123489
+            assert trace.samples[1].obs.reward[0] == 1.0
             np.testing.assert_equal(
-                trace.samples[0][0].entities["hero"][0].as_array(),
+                trace.samples[0].obs.entities["hero"][0].as_array(),
                 np.array([[1.0, 2.0, 0.3, 100.0, 10.0]], dtype=np.float32),
             )
             np.testing.assert_equal(
-                trace.samples[1][0].entities["hero"][0].as_array(),
+                trace.samples[1].obs.entities["hero"][0].as_array(),
                 np.array([[1.0, 2.0, 0.3, 200.0, 10.0]], dtype=np.float32),
             )

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -270,7 +270,7 @@ def train(args: argparse.Namespace) -> float:
 
         config = vars(args)
         if os.path.exists("/xprun/info/config.ron"):
-            import xprun  # type: ignore
+            import xprun
 
             xp_info = xprun.current_xp()
             config["name"] = xp_info.xp_def.name

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -38,7 +38,7 @@ from entity_gym.environment import (
 )
 from entity_gym.envs import ENV_REGISTRY
 from enn_zoo.griddly import GRIDDLY_ENVS, create_env
-from enn_ppo.sample_recorder import SampleRecorder
+from enn_ppo.sample_recorder import SampleRecorder, Sample
 from enn_ppo.simple_trace import Tracer
 from rogue_net.relpos_encoding import RelposEncodingConfig
 from rogue_net.actor import AutoActor
@@ -256,7 +256,7 @@ def train(args: argparse.Namespace) -> float:
             xp_info.xp_def.project,
             xp_info.sanitized_name + "-" + xp_info.id,
         )
-        Path(out_dir).mkdir(parents=True, exist_ok=True)
+        Path(str(out_dir)).mkdir(parents=True, exist_ok=True)
     else:
         out_dir = None
 
@@ -430,9 +430,13 @@ def train(args: argparse.Namespace) -> float:
             if args.capture_samples:
                 with tracer.span("record_samples"):
                     sample_recorder.record(
-                        next_obs,
-                        step=curr_step,
-                        episode=episodes,
+                        Sample(
+                            next_obs,
+                            step=curr_step,
+                            episode=episodes,
+                            actions=action,
+                            probs=logprob,
+                        )
                     )
 
             # Join all actions with corresponding `EntityID`s

--- a/entity_gym/entity_gym/environment.py
+++ b/entity_gym/entity_gym/environment.py
@@ -430,6 +430,13 @@ class VecEnv(ABC):
     ) -> ObsBatch:
         raise NotImplementedError
 
+    @abstractmethod
+    def __len__(self) -> int:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        pass
+
 
 class EnvList(VecEnv):
     def __init__(
@@ -468,6 +475,9 @@ class EnvList(VecEnv):
             else:
                 observations.append(obs)
         return batch_obs(observations, self.cls.obs_space(), self.cls.action_space())
+
+    def __len__(self) -> int:
+        return len(self.envs)
 
 
 class CloudpickleWrapper:
@@ -687,3 +697,6 @@ class ParallelEnvList(VecEnv):
             remote_obs_batch = remote.recv()
             observations.merge_obs(remote_obs_batch)
         return observations
+
+    def __len__(self) -> int:
+        return self.num_envs

--- a/entity_gym/entity_gym/sample_recorder.py
+++ b/entity_gym/entity_gym/sample_recorder.py
@@ -171,10 +171,16 @@ class Trace:
                 pbar.update(size + 8)
         return Trace(None, None, samples)  # type: ignore
 
-    def episodes(self, include_incomplete: bool = False) -> List[Episode]:
+    def episodes(
+        self, include_incomplete: bool = False, progress_bar: bool = False
+    ) -> List[Episode]:
         episodes = {}
         prev_episodes: Optional[List[int]] = None
-        for sample in tqdm.tqdm(self.samples):
+        if progress_bar:
+            samples = tqdm.tqdm(self.samples)
+        else:
+            samples = self.samples
+        for sample in samples:
             for i, e in enumerate(sample.episode):
                 if e not in episodes:
                     episodes[e] = Episode(e, 0, {}, {}, {}, {}, 0.0)

--- a/entity_gym/entity_gym/test_sample_recorder.py
+++ b/entity_gym/entity_gym/test_sample_recorder.py
@@ -68,7 +68,8 @@ def test_serde_sample() -> None:
                 )
             ),
         },
-        actions={},
+        logits=None,
+        actions=[],
         step=[13],
         episode=[4213],
     )

--- a/entity_gym/entity_gym/test_sample_recorder.py
+++ b/entity_gym/entity_gym/test_sample_recorder.py
@@ -1,6 +1,6 @@
 import numpy as np
 import tempfile
-from enn_ppo.sample_recorder import Sample, SampleRecorder, Trace
+from entity_gym.sample_recorder import Sample, SampleRecorder, Trace
 from entity_gym.environment import CategoricalActionMaskBatch, ObsBatch
 from numpy.lib.twodim_base import mask_indices
 from ragged_buffer import RaggedBufferF32, RaggedBufferI64

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -26,7 +26,13 @@ class ActionHead(nn.Module):
         index_offsets: RaggedBufferI64,
         mask: ActionMaskBatch,
         prev_actions: Optional[RaggedBufferI64],
-    ) -> Tuple[RaggedBufferI64, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[
+        RaggedBufferI64,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
         raise NotImplementedError()
 
 
@@ -43,7 +49,9 @@ class CategoricalActionHead(nn.Module):
         index_offsets: RaggedBufferI64,
         mask: ActionMaskBatch,
         prev_actions: Optional[RaggedBufferI64],
-    ) -> Tuple[torch.Tensor, npt.NDArray[np.int64], torch.Tensor, torch.Tensor]:
+    ) -> Tuple[
+        torch.Tensor, npt.NDArray[np.int64], torch.Tensor, torch.Tensor, torch.Tensor
+    ]:
         assert isinstance(
             mask, CategoricalActionMaskBatch
         ), f"Expected CategoricalActionMaskBatch, got {type(mask)}"
@@ -68,7 +76,7 @@ class CategoricalActionHead(nn.Module):
             action = torch.tensor(prev_actions.as_array()).to(x.data.device)
         logprob = dist.log_prob(action)
         entropy = dist.entropy()
-        return action, lengths, logprob, entropy
+        return action, lengths, logprob, entropy, logits
 
 
 class PaddedSelectEntityActionHead(nn.Module):
@@ -90,7 +98,9 @@ class PaddedSelectEntityActionHead(nn.Module):
         index_offsets: RaggedBufferI64,
         mask: ActionMaskBatch,
         prev_actions: Optional[RaggedBufferI64],
-    ) -> Tuple[torch.Tensor, npt.NDArray[np.int64], torch.Tensor, torch.Tensor]:
+    ) -> Tuple[
+        torch.Tensor, npt.NDArray[np.int64], torch.Tensor, torch.Tensor, torch.Tensor
+    ]:
         assert isinstance(
             mask, SelectEntityActionMaskBatch
         ), f"Expected SelectEntityActionMaskBatch, got {type(mask)}"
@@ -162,6 +172,7 @@ class PaddedSelectEntityActionHead(nn.Module):
             actor_lengths,
             logprob.flatten()[qindices].view(-1, 1),
             entropy.flatten()[qindices].view(-1, 1),
+            logits,
         )
 
 

--- a/xprun/train.ron
+++ b/xprun/train.ron
@@ -62,6 +62,9 @@ XpV0(
             env_secrets: {
                 "WANDB_API_KEY": "wandb-api-key",
             },
+            volumes: {
+                "/mnt/a/Dropbox/artifacts/xprun": "/mnt/xprun",
+            },
         )
     }
 )


### PR DESCRIPTION
- move `SampleRecorder` into the entity-gym package
- add `VecEnv` wrapper that records samples
- option to record full logits, not just probability of chosen action
- group loaded samples by episode