### PR TITLE
Add CodeCraft environment

### DIFF
--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -42,6 +42,7 @@ from entity_gym.environment.env_list import EnvList
 from entity_gym.environment.parallel_env_list import ParallelEnvList
 from entity_gym.examples import ENV_REGISTRY
 from enn_zoo.griddly import GRIDDLY_ENVS, create_env
+from enn_zoo.codecraft.vec_env import CodeCraftEnv, CodeCraftVecEnv
 from entity_gym.serialization import SampleRecordingVecEnv
 from enn_ppo.simple_trace import Tracer
 from rogue_net.relpos_encoding import RelposEncodingConfig
@@ -542,6 +543,8 @@ def train(args: argparse.Namespace) -> float:
     elif args.gym_id in GRIDDLY_ENVS:
         path, level = GRIDDLY_ENVS[args.gym_id]
         env_cls = create_env(yaml_file=path, level=level)
+    elif args.gym_id == "CodeCraft":
+        env_cls = CodeCraftEnv
     else:
         raise KeyError(
             f"Unknown gym_id: {args.gym_id}\nAvailable environments: {list(ENV_REGISTRY.keys()) + list(GRIDDLY_ENVS.keys())}"
@@ -554,7 +557,9 @@ def train(args: argparse.Namespace) -> float:
     else:
         eval_env_kwargs = env_kwargs
     envs: VecEnv
-    if args.processes > 1:
+    if args.gym_id == "CodeCraft":
+        envs = CodeCraftVecEnv(args.num_envs, 0)
+    elif args.processes > 1:
         envs = ParallelEnvList(env_cls, env_kwargs, args.num_envs, args.processes)
     else:
         envs = EnvList(env_cls, env_kwargs, args.num_envs)

--- a/enn_ppo/pyproject.toml
+++ b/enn_ppo/pyproject.toml
@@ -11,10 +11,10 @@ tensorboard = "^2.7.0"
 msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 tqdm = "^4.62.3"
-ragged-buffer = "^0.3.3"
+ragged-buffer = "^0.3.4"
 wandb = "^0.12.7"
 optuna = "^2.10.0"
-enn_zoo = {path = "../enn_zoo", develop=true}
+enn_zoo = {path = "../enn_zoo", develop = true}
 entity_gym = {path = "../entity_gym", develop = true}
 rogue_net = {path = "../rogue_net", develop = true}
 

--- a/enn_zoo/enn_zoo/codecraft/rest_client.py
+++ b/enn_zoo/enn_zoo/codecraft/rest_client.py
@@ -1,0 +1,317 @@
+import requests
+import logging
+import time
+import os
+
+import orjson
+import numpy as np
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple, Dict
+
+
+RETRIES = 100
+
+
+@dataclass
+class ObsConfig:
+    allies: int
+    drones: int
+    minerals: int
+    tiles: int
+    num_builds: int
+    relative_positions: bool = False
+    feat_last_seen: bool = False
+    feat_map_size: bool = True
+    feat_is_visible: bool = True
+    feat_abstime: bool = True
+    v2: bool = True
+    feat_rule_msdm: bool = True
+    feat_rule_costs: bool = True
+    feat_mineral_claims: bool = False
+    harvest_action: bool = False
+    lock_build_action: bool = False
+    feat_dist_to_wall: bool = False
+    unit_count: bool = True
+    construction_progress: bool = True
+
+    def global_features(self) -> int:
+        gf = 2
+        if self.feat_map_size:
+            gf += 2
+        if self.feat_abstime:
+            gf += 2
+        if self.feat_rule_msdm:
+            gf += 1
+        if self.feat_rule_costs:
+            gf += self.num_builds
+        if self.unit_count:
+            gf += 1
+        return gf
+
+    def dstride(self) -> int:
+        ds = 17
+        if self.feat_last_seen:
+            ds += 2
+        if self.feat_is_visible:
+            ds += 1
+        if self.lock_build_action:
+            ds += 1
+        if self.feat_dist_to_wall:
+            ds += 5
+        if self.construction_progress:
+            ds += self.num_builds + 2
+        return ds
+
+    def mstride(self) -> int:
+        return 4 if self.feat_mineral_claims else 3
+
+    def tstride(self) -> int:
+        return 4
+
+    def nonobs_features(self) -> int:
+        return 5
+
+    def enemies(self) -> int:
+        return self.drones - self.allies
+
+    def total_drones(self) -> int:
+        return 2 * self.drones - self.allies
+
+    def stride(self) -> int:
+        return (
+            self.global_features()
+            + self.total_drones() * self.dstride()
+            + self.minerals * self.mstride()
+            + self.tiles * self.tstride()
+        )
+
+    def endglobals(self) -> int:
+        return self.global_features()
+
+    def endallies(self) -> int:
+        return self.global_features() + self.dstride() * self.allies
+
+    def endenemies(self) -> int:
+        return self.global_features() + self.dstride() * self.drones
+
+    def endmins(self) -> int:
+        return self.endenemies() + self.mstride() * self.minerals
+
+    def endtiles(self) -> int:
+        return self.endmins() + self.tstride() * self.tiles
+
+    def endallenemies(self) -> int:
+        return self.endtiles() + self.dstride() * self.enemies()
+
+    def extra_actions(self) -> int:
+        if self.lock_build_action:
+            return 2
+        else:
+            return 0
+
+
+@dataclass
+class Rules:
+    mothership_damage_multiplier: float
+    cost_modifiers: Dict[Tuple[int, int, int, int, int, int], float]
+
+
+def create_game(
+    game_length: Optional[int] = None,
+    action_delay: int = 0,
+    self_play: bool = False,
+    custom_map: Optional[Dict[str, Any]] = None,
+    scripted_opponent: str = "none",
+    rules: Optional[Rules] = None,
+    allowHarvesting: bool = True,
+    forceHarvesting: bool = True,
+    randomizeIdle: bool = True,
+) -> int:
+    assert rules is not None
+    json = {
+        "map": [] if custom_map is None else [custom_map],
+        "costModifiers": list(rules.cost_modifiers.items()),
+    }
+    try:
+        if game_length:
+            response = requests.post(
+                f"http://{get_hostname()}:9000/start-game"
+                f"?maxTicks={game_length}"
+                f"&actionDelay={action_delay}"
+                f"&scriptedOpponent={scripted_opponent}"
+                f"&mothershipDamageMultiplier={rules.mothership_damage_multiplier}"
+                f"&allowHarvesting={scalabool(allowHarvesting)}"
+                f"&forceHarvesting={scalabool(forceHarvesting)}"
+                f"&randomizeIdle={scalabool(randomizeIdle)}",
+                json=json,
+            ).json()
+        else:
+            response = requests.post(
+                f"http://{get_hostname()}:9000/start-game?actionDelay={action_delay}"
+            ).json()
+        return int(response["id"])
+    except requests.exceptions.ConnectionError:
+        logging.info(f"Connection error on create_game, retrying")
+        time.sleep(1)
+        return create_game(
+            game_length,
+            action_delay,
+            self_play,
+            custom_map=custom_map,
+            scripted_opponent=scripted_opponent,
+            rules=rules,
+            allowHarvesting=allowHarvesting,
+            forceHarvesting=forceHarvesting,
+            randomizeIdle=randomizeIdle,
+        )
+
+
+def act_batch(actions: List[Tuple[int, int, Any]]) -> None:
+    payload = {}
+    for game_id, player_id, player_actions in actions:
+        player_actions_json = []
+        for (
+            move,
+            turn,
+            buildSpec,
+            harvest,
+            lockBuildAction,
+            unlockBuildAction,
+        ) in player_actions:
+            player_actions_json.append(
+                {
+                    "buildDrone": buildSpec,
+                    "move": move,
+                    "harvest": harvest,
+                    "transfer": False,
+                    "turn": turn,
+                    "lockBuildAction": lockBuildAction,
+                    "unlockBuildAction": unlockBuildAction,
+                }
+            )
+        payload[f"{game_id}.{player_id}"] = player_actions_json
+
+    retries = 100
+    while retries > 0:
+        try:
+            requests.post(
+                f"http://{get_hostname()}:9000/batch-act",
+                data=orjson.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            ).raise_for_status()
+            return
+        except requests.exceptions.ConnectionError:
+            # For some reason, a small percentage of requests fails with
+            # "connection error (errno 98, address already in use)"
+            # Just retry
+            retries -= 1
+            logging.info(f"Connection error on act_batch(), retrying")
+            time.sleep(1)
+
+
+def scalabool(b: bool) -> str:
+    return "true" if b else "false"
+
+
+def observe_batch_raw(
+    obs_config: ObsConfig,
+    game_ids: List[Tuple[int, int]],
+    allies: int,
+    drones: int,
+    minerals: int,
+    tiles: int,
+    relative_positions: bool,
+    v2: bool,
+    extra_build_actions: List[Tuple[int, int, int, int, int, int]],
+    map_size: bool = False,
+    last_seen: bool = False,
+    is_visible: bool = False,
+    abstime: bool = False,
+    rule_msdm: bool = False,
+    rule_costs: bool = False,
+    enforce_unit_cap: bool = False,
+    unit_cap_override: int = 0,
+) -> np.ndarray:
+    retries = RETRIES
+    url = (
+        f"http://{get_hostname()}:9000/batch-observation?"
+        f"json=false&"
+        f"allies={allies}&"
+        f"drones={drones}&"
+        f"minerals={minerals}&"
+        f"tiles={tiles}&"
+        f"globalDrones=0&"
+        f'relativePositions={"true" if relative_positions else "false"}&'
+        f'lastSeen={"true" if last_seen else "false"}&'
+        f'isVisible={"true" if is_visible else "false"}&'
+        f'abstime={"true" if abstime else "false"}&'
+        f'mapSize={"true" if map_size else "false"}&'
+        f'v2={"true" if v2 else "false"}&'
+        f"mineralClaims={scalabool(obs_config.feat_mineral_claims)}&"
+        f"harvestAction={scalabool(obs_config.harvest_action)}&"
+        f"ruleMsdm={scalabool(rule_msdm)}&"
+        f"ruleCosts={scalabool(rule_costs)}&"
+        f"lockBuildAction={scalabool(obs_config.lock_build_action)}&"
+        f"distanceToWall={scalabool(obs_config.feat_dist_to_wall)}&"
+        f"unitCount={scalabool(obs_config.unit_count)}&"
+        f"enforceUnitCap={scalabool(enforce_unit_cap)}&"
+        f"unitCapOverride={unit_cap_override}&"
+        f"constructionProgress={scalabool(obs_config.construction_progress)}"
+    )
+    while retries > 0:
+        json = [game_ids, extra_build_actions]
+        try:
+            response = requests.get(url, json=json, stream=True)
+            response.raise_for_status()
+            response_bytes = response.content
+            return np.frombuffer(response_bytes, dtype=np.float32)  # type: ignore
+        except requests.exceptions.ConnectionError as e:
+            retries -= 1
+            logging.info(f"Connection error on {url} with json={json}, retrying: {e}")
+            time.sleep(10)
+    raise RuntimeError(f"Failed to connect to {url} after {RETRIES} retries")
+
+
+def get_hostname() -> str:
+    xprun_id = os.getenv("XPRUN_ID")
+    if xprun_id:
+        return f"xprun.{xprun_id}.codecraftserver-0"
+    else:
+        return "localhost"
+
+
+def observe_batch(game_ids: List[Tuple[int, int]]) -> Any:
+    retries = RETRIES
+    while retries > 0:
+        try:
+            return requests.get(
+                f"http://{get_hostname()}:9000/batch-observation", json=[game_ids, []]
+            ).json()
+        except requests.exceptions.ConnectionError:
+            retries -= 1
+            logging.info(f"Connection error on observe_batch(), retrying")
+            time.sleep(10)
+
+
+def observe(game_id: int, player_id: int = 0) -> Any:
+    try:
+        return requests.get(
+            f"http://{get_hostname()}:9000/observation?gameID={game_id}&playerID={player_id}"
+        ).json()
+    except requests.exceptions.ConnectionError:
+        logging.info(f"Connection error on observe({game_id}.{player_id}), retrying")
+        time.sleep(1)
+        return observe(game_id, player_id)
+
+
+def dist(x1: float, y1: float, x2: float, y2: float) -> float:
+    dx = x1 - x2
+    dy = y1 - y2
+    return np.sqrt(dx * dx + dy * dy)  # type: ignore
+
+
+def dist2(x1: float, y1: float, x2: float, y2: float) -> float:
+    dx = x1 - x2
+    dy = y1 - y2
+    return dx * dx + dy * dy

--- a/enn_zoo/enn_zoo/codecraft/vec_env.py
+++ b/enn_zoo/enn_zoo/codecraft/vec_env.py
@@ -1,0 +1,897 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+import math
+import time
+from enn_zoo.codecraft import rest_client
+from enn_zoo.codecraft.rest_client import ObsConfig, Rules
+import numpy as np
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Type
+from ragged_buffer import RaggedBufferF32, RaggedBufferI64, RaggedBufferBool
+from entity_gym.environment import VecEnv
+from entity_gym.environment.vec_env import CategoricalActionMaskBatch
+from entity_gym.environment import Environment, ObsSpace, ObsBatch
+from entity_gym.environment.environment import (
+    Action,
+    ActionSpace,
+    CategoricalActionSpace,
+    Entity,
+    Observation,
+    EpisodeStats,
+)
+
+DRONE_FEATS = [
+    "x",
+    "y",
+    "orientation_x",
+    "orientation_y",
+    "stored_resources",
+    "is_constructing",
+    "is_harvesting",
+    "hitpoints",
+    "storage_modules",
+    "missile_batteries",
+    "constructors",
+    "engines",
+    "shield_generators",
+    "long_range_missiles",
+    "is_stunned",
+    "is_enemy",
+    # feat_last_seen
+    # "time_since_visible",
+    # "missile_cooldown",
+    "long_range_missile_chargeup",
+    "is_visible",
+    # lock_build_action
+    # "build_action_locked",
+    # feat_dist_to_wall
+    # "distance_to_wall_0",
+    # "distance_to_wall_1",
+    # "distance_to_wall_2",
+    # "distance_to_wall_3",
+    # "distance_to_wall_4",
+    "available_energy",
+    "required_energy",
+    # TODO: more than one build
+    "constructing_1m",
+    # global features
+    "relative_elapsed_time",
+    "allied_score",
+    "map_height",
+    "map_width",
+    "timestep",
+    "remaining_timesteps",
+    "msdm",
+    "cost_multiplier_1m",
+    "unit_count",
+]
+
+
+class CodeCraftEnv(Environment):
+    @classmethod
+    def obs_space(cls) -> ObsSpace:
+        return ObsSpace(
+            entities={
+                "ally": Entity(list(DRONE_FEATS)),
+                "enemy": Entity(list(DRONE_FEATS)),
+                "mineral": Entity(
+                    [
+                        "x",
+                        "y",
+                        "size",
+                        # "claimed",
+                    ]
+                ),
+                "tile": Entity(
+                    [
+                        "x",
+                        "y",
+                        "last_visited_time",
+                        "visited",
+                    ]
+                ),
+            }
+        )
+
+    @classmethod
+    def action_space(cls) -> Dict[str, ActionSpace]:
+        return {
+            # 0-5: turn/movement (4 is no turn, no movement)
+            # 6: build [0,1,0,0,0] drone (if minerals > 5)
+            # 7: harvest
+            "act": CategoricalActionSpace(
+                [
+                    "move_left",
+                    "move_forward",
+                    "move_right",
+                    "turn_left",
+                    "halt",
+                    "turn_right",
+                    "build_1m",
+                    "harvest",
+                    # feat_lock_build_action
+                    # "unlock_build_action",
+                    # "lock_build_action",
+                ]
+            )
+        }
+
+    def _reset(self) -> Observation:
+        raise NotImplementedError
+
+    def _act(self, action: Mapping[str, Action]) -> Observation:
+        raise NotImplementedError
+
+    def close(self) -> None:
+        pass
+
+    @classmethod
+    def filter_obs(cls, obs: Observation, obs_filter: ObsSpace) -> Observation:
+        selectors = cls._compile_feature_filter(obs_filter)
+        entities = {
+            entity_name: entity_features[:, selectors[entity_name]].reshape(
+                entity_features.shape[0], len(selectors[entity_name])
+            )
+            for entity_name, entity_features in obs.entities.items()
+        }
+        return Observation(
+            entities,
+            obs.ids,
+            obs.action_masks,
+            obs.reward,
+            obs.done,
+            obs.end_of_episode_info,
+        )
+
+    def env_cls(self) -> Type["Environment"]:
+        return self.__class__
+
+
+class Objective(Enum):
+    ALLIED_WEALTH = "ALLIED_WEALTH"
+    DISTANCE_TO_CRYSTAL = "DISTANCE_TO_CRYSTAL"
+    DISTANCE_TO_ORIGIN = "DISTANCE_TO_ORIGIN"
+    DISTANCE_TO_1000_500 = "DISTANCE_TO_1000_500"
+    ARENA_TINY = "ARENA_TINY"
+    ARENA_TINY_2V2 = "ARENA_TINY_2V2"
+    ARENA_MEDIUM = "ARENA_MEDIUM"
+    ARENA_MEDIUM_LARGE_MS = "ARENA_MEDIUM_LARGE_MS"
+    ARENA = "ARENA"
+    STANDARD = "STANDARD"
+    ENHANCED = "ENHANCED"
+    SMOL_STANDARD = "SMOL_STANDARD"
+    MICRO_PRACTICE = "MICRO_PRACTICE"
+    SCOUT = "SCOUT"
+
+    def vs(self) -> bool:
+        if (
+            self == Objective.ALLIED_WEALTH
+            or self == Objective.DISTANCE_TO_CRYSTAL
+            or self == Objective.DISTANCE_TO_ORIGIN
+            or self == Objective.DISTANCE_TO_1000_500
+            or self == Objective.SCOUT
+        ):
+            return False
+        elif (
+            self == Objective.ARENA_TINY
+            or self == Objective.ARENA_TINY_2V2
+            or self == Objective.ARENA_MEDIUM
+            or self == Objective.ARENA
+            or self == Objective.STANDARD
+            or self == Objective.ENHANCED
+            or self == Objective.SMOL_STANDARD
+            or self == Objective.MICRO_PRACTICE
+            or self == Objective.ARENA_MEDIUM_LARGE_MS
+        ):
+            return True
+        else:
+            raise Exception(f"Objective.vs not implemented for {self}")
+
+    def naction(self) -> int:
+        return 8 + len(self.extra_builds())
+
+    def builds(self) -> List[Tuple[int, int, int, int, int, int]]:
+        b = self.extra_builds()
+        b.append((0, 1, 0, 0, 0, 0))
+        return b
+
+    def extra_builds(self) -> List[Tuple[int, int, int, int, int, int]]:
+        # [storageModules, missileBatteries, constructors, engines, shieldGenerators]
+        if self == Objective.ARENA:
+            return [(1, 0, 1, 0, 0, 0), (0, 2, 0, 0, 0, 0), (0, 1, 0, 0, 1, 0)]
+        elif self == Objective.SMOL_STANDARD or self == Objective.STANDARD:
+            return [
+                (1, 0, 1, 0, 0, 0),
+                (0, 2, 0, 0, 0, 0),
+                (0, 1, 0, 0, 1, 0),
+                (0, 3, 0, 0, 1, 0),
+                (0, 2, 0, 0, 2, 0),
+                (2, 1, 1, 0, 0, 0),
+                (2, 0, 2, 0, 0, 0),
+                (2, 0, 1, 1, 0, 0),
+                (0, 2, 0, 1, 1, 0),
+                (1, 0, 0, 0, 0, 0),
+            ]
+        elif self == Objective.ENHANCED:
+            return [
+                # [s, m, c, e, p, l]
+                (1, 0, 0, 0, 0, 0),  # 1s
+                (1, 0, 1, 0, 0, 0),  # 1s1c
+                (0, 1, 0, 0, 1, 0),  # 1m1p
+                (0, 0, 0, 0, 0, 2),  # 2l
+                (0, 2, 0, 2, 0, 0),  # 2m2e
+                (0, 1, 0, 2, 1, 0),  # 1m1p2e
+                (0, 2, 0, 1, 1, 0),  # 2m1e1p
+                (0, 0, 0, 1, 0, 3),  # 1e3l
+                (2, 0, 1, 1, 0, 0),  # 2s1c1e
+                (0, 4, 0, 3, 3, 0),  # 4m3e3p
+                (0, 0, 0, 4, 1, 5),  # 4e1p5l
+            ]
+        else:
+            return []
+
+
+@dataclass
+class TaskConfig:
+    objective: Objective = Objective.ARENA_TINY_2V2
+    use_action_masks: bool = True
+    task_hardness: float = 0
+    # Max length of games, or default game length for map if 0.
+    max_game_length: int = 0
+    randomize: bool = True
+    # Percentage of maps which are symmetric
+    symmetric_map: float = 0.0
+    # Linearly increase env symmetry parameter with this slope for every step
+    symmetry_increase: float = 2e-8
+    # Fraction of maps that use randomize ruleset
+    rule_rng_fraction: float = 0.0
+    # Amount of rule randomization
+    rule_rng_amount: float = 1.0
+    rule_cost_rng: float = 0.0
+    # Automatically adjust environment rules
+    adr: bool = False
+    # Amount by which task difficulty/map size is increased for each processed frame
+    mothership_damage_scale: float = 0.0
+    enforce_unit_cap: bool = False
+    unit_cap: int = 20
+
+    # Set by ppo
+    build_variety_bonus: float = 0.0
+    # Set by adr
+    cost_variance: float = 0.0
+
+
+class CodeCraftVecEnv(VecEnv):
+    def __init__(
+        self,
+        num_envs: int,
+        num_self_play: int,
+        objective: Objective = Objective.ALLIED_WEALTH,
+        config: TaskConfig = TaskConfig(),
+        stagger: bool = True,
+        fair: bool = False,
+        randomize: bool = False,
+        use_action_masks: bool = True,
+        obs_config: ObsConfig = ObsConfig(
+            allies=1, drones=1, minerals=10, tiles=0, num_builds=1
+        ),
+        hardness: int = 0,
+        symmetric: float = 0.0,
+        scripted_opponents: Optional[List[Tuple[str, int]]] = None,
+        win_bonus: float = 0.0,
+        attac: float = 0.0,
+        protec: float = 0.0,
+        max_army_size_score: int = 999999,
+        max_enemy_army_size_score: int = 999999,
+        rule_rng_fraction: float = 0.0,
+        rule_rng_amount: float = 0.0,
+        rule_cost_rng: float = 0.0,
+        max_game_length: Optional[int] = None,
+        stagger_offset: float = 0.0,
+        loss_penalty: float = 0.0,
+        partial_score: float = 1.0,
+        create_game_delay: float = 0.0,
+    ) -> None:
+        assert num_envs >= 2 * num_self_play
+        self.num_envs = num_envs
+        self.objective = objective
+        self.num_self_play = num_self_play
+        self.stagger = stagger
+        self.stagger_offset = stagger_offset
+        self.fair = fair
+        self.game_length = 3 * 60 * 60
+        self.custom_map: Callable[
+            [bool, int, bool], Optional[Dict[str, Any]]
+        ] = lambda _1, _2, _3: None
+        self.last_map: Optional[Dict[str, Any]] = None
+        self.randomize = randomize
+        self.use_action_masks = use_action_masks
+        self.obs_config = obs_config
+        self.hardness = hardness
+        self.symmetric = symmetric
+        self.win_bonus = win_bonus
+        self.loss_penalty = loss_penalty
+        self.partial_score = partial_score
+        self.attac = attac
+        self.protec = protec
+        self.max_army_size_score = max_army_size_score
+        self.max_enemy_army_size_score = max_enemy_army_size_score
+        self.rule_rng_fraction = rule_rng_fraction
+        self.rule_rng_amount = rule_rng_amount
+        self.rule_cost_rng = rule_cost_rng
+        self.rng_ruleset = None
+        self.allow_harvesting = objective != Objective.DISTANCE_TO_CRYSTAL
+        self.force_harvesting = False
+        self.randomize_idle = objective != Objective.ALLIED_WEALTH
+        self.config = config
+        self.create_game_delay = create_game_delay
+
+        remaining_scripted = num_envs - 2 * num_self_play
+        self.scripted_opponents = []
+        if scripted_opponents is not None:
+            for opponent, count in scripted_opponents:
+                remaining_scripted -= count
+                for _ in range(count):
+                    self.scripted_opponents.append(opponent)
+        for _ in range(remaining_scripted):
+            self.scripted_opponents.append("idle")
+        self.next_opponent_index = 0
+
+        self.builds = objective.extra_builds()
+        if objective == Objective.ALLIED_WEALTH:
+            self.custom_map = map_allied_wealth
+            self.game_length = 1 * 60 * 60
+        else:
+            raise NotImplementedError(objective)
+        if max_game_length is not None:
+            self.game_length = max_game_length
+        self.build_costs = [sum(modules) for modules in self.builds]
+        self.base_naction = 8 + len(self.builds)
+        assert len(self.builds) + 1 == obs_config.num_builds
+
+        self.game_count = 0
+
+        self.games: List[Tuple[int, int, str]] = []
+        self.eplen: List[int] = []
+        self.eprew: List[float] = []
+        self.score: List[Optional[float]] = []
+        self.performed_builds: List[Any] = []
+        self.rulesets: List[Any] = []
+
+    def rules(self) -> Rules:
+        # if np.random.uniform(0, 1) < self.rule_rng_fraction:
+        #    return random_rules(
+        #        2 ** self.config.mothership_damage_scale,
+        #        self.rule_cost_rng,
+        #        self.rng_ruleset,
+        #        self.config.cost_variance,
+        #    )
+        # else:
+        return Rules(
+            mothership_damage_multiplier=2 ** self.config.mothership_damage_scale,
+            cost_modifiers={build: 1.0 for build in self.objective.builds()},
+        )
+
+    def next_opponent(self) -> str:
+        opp = self.scripted_opponents[self.next_opponent_index]
+        self.next_opponent_index += 1
+        if self.next_opponent_index == len(self.scripted_opponents):
+            self.next_opponent_index = 0
+        return opp
+
+    def reset(self, obs_config: ObsSpace) -> ObsBatch:
+        self.games = []
+        self.eplen = []
+        self.score = []
+        self.performed_builds = []
+        self.rulesets = []
+        for i in range(self.num_envs - self.num_self_play):
+            # spread out initial game lengths to stagger start times
+            self_play = i < self.num_self_play
+            game_length = (
+                int(
+                    self.game_length
+                    * (i + 1 - self.stagger_offset)
+                    // (self.num_envs - self.num_self_play)
+                )
+                if self.stagger
+                else self.game_length
+            )
+            opponent = "none" if self_play else self.next_opponent()
+            ruleset = self.rules()
+            game_id = rest_client.create_game(
+                game_length,
+                0,
+                self_play,
+                self.next_map(
+                    require_default_mothership=opponent not in ["none", "idle"]
+                ),
+                opponent,
+                ruleset,
+                self.allow_harvesting,
+                self.force_harvesting,
+                self.randomize_idle,
+            )
+            self.game_count += 1
+
+            self.games.append((game_id, 0, opponent))
+            self.eplen.append(1)
+            self.eprew.append(0)
+            self.score.append(None)
+            self.performed_builds.append(defaultdict(lambda: 0))
+            self.rulesets.append(ruleset)
+            if self_play:
+                self.games.append((game_id, 1, opponent))
+                self.eplen.append(1)
+                self.eprew.append(0)
+                self.score.append(None)
+                self.performed_builds.append(defaultdict(lambda: 0))
+                self.rulesets.append(ruleset)
+
+        return self.observe(obs_config)
+
+    def act(
+        self, actions: Sequence[Mapping[str, Action]], obs_filter: ObsSpace
+    ) -> ObsBatch:
+        return self.step(
+            [[a[1] for a in act["act"].actions] for act in actions], obs_filter
+        )
+
+    def step(
+        self,
+        actions: List[List[int]],
+        # env_subset: Optional[List[int]] = None,
+        # obs_config: Optional[ObsConfig] = None,
+        obs_filter: ObsSpace,
+        action_masks: Optional[Any] = None,
+    ) -> ObsBatch:
+        self.step_async(actions, action_masks)
+        return self.observe(obs_filter)
+
+    def step_async(
+        self,
+        actions: List[List[int]],
+        # env_subset: Optional[List[int]] = None,
+        action_masks: Optional[Any] = None,
+    ) -> None:
+        game_actions = []
+        # games = [self.games[env] for env in env_subset] if env_subset else self.games
+        games = self.games
+        for (i, ((game_id, player_id, opponent), player_actions)) in enumerate(
+            zip(games, actions)
+        ):
+            if action_masks is not None:
+                action_masks_i = action_masks[i]
+            player_actions2 = []
+            for (drone_index, action) in enumerate(player_actions):
+                if action_masks is not None:
+                    action_masks_drone = action_masks_i[drone_index]
+                # 0-5: turn/movement (4 is no turn, no movement)
+                # 6: build [0,1,0,0,0] drone (if minerals > 5)
+                # 7: harvest
+                move = False
+                harvest = False
+                turn = 0
+                build = []
+                lockBuildAction = False
+                unlockBuildAction = False
+                if action == 0 or action == 1 or action == 2:
+                    move = True
+                if action == 0 or action == 3:
+                    turn = -1
+                if action == 2 or action == 5:
+                    turn = 1
+                if action == 6:
+                    build = [(0, 1, 0, 0, 0, 0)]
+                if action == 7:
+                    harvest = True
+                elif action == 8 + len(self.builds) + 1:
+                    unlockBuildAction = True
+                elif action >= 8:
+                    b = action - 8
+                    if b < len(self.builds):
+                        build = [self.builds[b]]
+                    else:
+                        build = [(0, 1, 0, 0, 0, 0)]
+                if (
+                    len(build) > 0
+                    and action_masks is not None
+                    and action_masks_drone[action] == 1.0
+                ):
+                    self.performed_builds[i][build[0]] += 1
+                player_actions2.append(
+                    (move, turn, build, harvest, lockBuildAction, unlockBuildAction)
+                )
+            game_actions.append((game_id, player_id, player_actions2))
+
+        rest_client.act_batch(game_actions)
+
+    def observe(self, obs_filter: ObsSpace) -> ObsBatch:
+        env_subset: Optional[List[int]] = None
+        obs_config: Optional[ObsConfig] = None
+        obs_config = obs_config or self.obs_config
+        games = [self.games[env] for env in env_subset] if env_subset else self.games
+        num_envs = len(games)
+
+        rews = []
+        dones = []
+        infos = {}
+        obs = rest_client.observe_batch_raw(
+            obs_config,
+            [(gid, pid) for (gid, pid, _) in games],
+            allies=obs_config.allies,
+            drones=obs_config.drones,
+            minerals=obs_config.minerals,
+            tiles=obs_config.tiles,
+            relative_positions=False,
+            v2=True,
+            extra_build_actions=self.builds,
+            map_size=obs_config.feat_map_size,
+            last_seen=obs_config.feat_last_seen,
+            is_visible=obs_config.feat_is_visible,
+            abstime=obs_config.feat_abstime,
+            rule_msdm=obs_config.feat_rule_msdm,
+            rule_costs=obs_config.feat_rule_costs,
+            enforce_unit_cap=self.config.enforce_unit_cap,
+            unit_cap_override=self.config.unit_cap,
+        )
+        stride = obs_config.stride()
+        for i in range(num_envs):
+            game = env_subset[i] if env_subset else i
+            winner = obs[stride * num_envs + i * obs_config.nonobs_features()]
+            outcome = 0
+            elimination_win = 0
+            if self.objective.vs():
+                allied_score = obs[
+                    stride * num_envs + i * obs_config.nonobs_features() + 1
+                ]
+                allied_score = min(allied_score, self.max_army_size_score)
+                enemy_score = obs[
+                    stride * num_envs + i * obs_config.nonobs_features() + 2
+                ]
+                enemy_score = min(enemy_score, self.max_enemy_army_size_score)
+                min_allied_ms_health = obs[
+                    stride * num_envs + i * obs_config.nonobs_features() + 3
+                ]
+                min_enemy_ms_health = obs[
+                    stride * num_envs + i * obs_config.nonobs_features() + 4
+                ]
+                score = (
+                    self.partial_score
+                    * 2
+                    * allied_score
+                    / (allied_score + enemy_score + 1e-8)
+                    - 1
+                )
+                if winner > 0:
+                    if enemy_score == 0:
+                        score += self.win_bonus
+                    else:
+                        score -= self.loss_penalty
+                if winner > 0:
+                    if enemy_score == 0 or allied_score == 0:
+                        elimination_win = 1
+                    if enemy_score + allied_score == 0:
+                        outcome = 0
+                    else:
+                        outcome = (allied_score - enemy_score) / (
+                            enemy_score + allied_score
+                        )
+                if self.attac > 0:
+                    score -= self.attac * min_enemy_ms_health
+                if self.protec > 0:
+                    score += self.protec * min_allied_ms_health
+            elif self.objective == Objective.SCOUT:
+                enemy_score = obs[
+                    stride * num_envs + i * obs_config.nonobs_features() + 2
+                ]
+                score = -enemy_score
+            elif self.objective == Objective.ALLIED_WEALTH:
+                score = (
+                    obs[stride * num_envs + i * obs_config.nonobs_features() + 1] * 0.1
+                )
+            elif self.objective == Objective.DISTANCE_TO_ORIGIN:
+                start = stride * i + obs_config.endglobals()
+                x = obs[start]
+                y = obs[start + 1]
+                score = -math.sqrt(x ** 2 + y ** 2) / 1000.0
+            elif self.objective == Objective.DISTANCE_TO_CRYSTAL:
+                dstart = stride * i + obs_config.endglobals()
+                xd = obs[dstart]
+                yd = obs[dstart + 1]
+                allmstart = stride * i + obs_config.endenemies()
+                score = 0.0
+                for m in range(obs_config.minerals):
+                    mstart = allmstart + obs_config.mstride() * m
+                    x = obs[mstart] - xd
+                    y = obs[mstart + 1] - yd
+                    size = obs[mstart + 2]
+                    nearness = 0.5 - math.sqrt(x ** 2 + y ** 2) / 1000.0
+                    score = max(score, 0.2 * nearness * size)
+            elif self.objective in [Objective.DISTANCE_TO_1000_500]:
+
+                raise Exception(f"Deprecated objective {self.objective}")
+            else:
+                raise Exception(f"Unknown objective {self.objective}")
+
+            if len(self.builds) > 0:
+                max_entropy = math.log(len(self.builds) + 1)
+                build_entropy = 0
+                s = sum(self.performed_builds[i].values())
+                for count in self.performed_builds[i].values():
+                    if count > 0:
+                        p = count / s
+                        build_entropy -= p * math.log(p)
+                score += self.config.build_variety_bonus * build_entropy / max_entropy
+
+            if self.score[game] is None:
+                self.score[game] = score
+            reward = score - self.score[game]
+            self.score[game] = score
+            self.eprew[game] += reward
+
+            if winner > 0:
+                (game_id, pid, opponent_was) = games[i]
+                previous_ruleset = self.rulesets[game]
+                if pid == 0:
+                    self_play = game // 2 < self.num_self_play
+                    opponent = "none" if self_play else self.next_opponent()
+                    ruleset = self.rules()
+                    if self.create_game_delay > 0:
+                        time.sleep(self.create_game_delay)
+                    game_id = rest_client.create_game(
+                        self.game_length,
+                        0,
+                        self_play,
+                        self.next_map(
+                            require_default_mothership=opponent not in ["none", "idle"]
+                        ),
+                        opponent,
+                        ruleset,
+                        self.allow_harvesting,
+                        self.force_harvesting,
+                        self.randomize_idle,
+                    )
+                    self.game_count += 1
+                else:
+                    game_id, _, opponent = self.games[game - 1]
+                    ruleset = self.rulesets[game - 1]
+                # print(f"COMPLETED {i} {game} {games[i]} == {self.games[game]} new={game_id}")
+                self.games[game] = (game_id, pid, opponent)
+                observation = rest_client.observe(game_id, pid)
+                # TODO: use actual observation
+                if not obs.flags["WRITEABLE"]:
+                    obs = obs.copy()
+                obs[
+                    stride * i : stride * (i + 1)
+                ] = 0.0  # codecraft.observation_to_np(observation)
+
+                dones.append(1.0)
+                infos[i] = EpisodeStats(self.eplen[game], self.eprew[game])
+                # {
+                #     "episode": {
+                #         "r": self.eprew[game],
+                #         "l": self.eplen[game],
+                #         "index": game,
+                #         "score": self.score[game],
+                #         "elimination": elimination_win,
+                #         "builds": self.performed_builds[game],
+                #         "outcome": outcome,
+                #         "opponent": opponent_was,
+                #         "ruleset": previous_ruleset,
+                #     }
+                # }
+                self.eplen[game] = 1
+                self.eprew[game] = 0
+                self.score[game] = None
+                self.performed_builds[game] = defaultdict(lambda: 0)
+                self.rulesets[game] = ruleset
+            else:
+                self.eplen[game] += 1
+                dones.append(0.0)
+
+            rews.append(reward)
+
+        naction = self.base_naction + obs_config.extra_actions()
+        action_mask_elems = naction * obs_config.allies * num_envs
+        action_masks = obs[-action_mask_elems:].reshape(-1, obs_config.allies, naction)
+
+        _obs = obs[: stride * self.num_envs].reshape(num_envs, -1)
+
+        globals = _obs[:, : obs_config.endglobals()]
+
+        # filter out all padding
+        allies = _obs[:, obs_config.endglobals() : obs_config.endallies()].reshape(
+            num_envs, obs_config.allies, obs_config.dstride()
+        )
+        allies = np.concatenate(
+            [allies, globals.reshape(num_envs, 1, obs_config.global_features())], axis=2
+        )
+        ally_not_padding = allies[:, :, 7] != 0
+        # TODO: hack
+        ally_not_padding[:, 0] = True
+        ragged_allies = RaggedBufferF32.from_flattened(
+            allies[ally_not_padding],
+            ally_not_padding.sum(axis=1).astype(np.int64),
+        )
+        enemies = _obs[:, obs_config.endallies() : obs_config.endenemies()].reshape(
+            num_envs, obs_config.enemies(), obs_config.dstride()
+        )
+        not_padding = enemies[:, :, 7] != 0
+        ragged_enemies = RaggedBufferF32.from_flattened(
+            enemies[not_padding],
+            not_padding.sum(axis=1).astype(np.int64),
+        )
+        minerals = _obs[:, obs_config.endenemies() : obs_config.endmins()].reshape(
+            num_envs, obs_config.minerals, obs_config.mstride()
+        )
+        not_padding = minerals[:, :, 2] != 0
+        ragged_minerals = RaggedBufferF32.from_flattened(
+            minerals[not_padding],
+            not_padding.sum(axis=1).astype(np.int64),
+        )
+        tiles = _obs[:, obs_config.endmins() : obs_config.endtiles()].reshape(
+            num_envs, obs_config.tiles, obs_config.tstride()
+        )
+        ragged_tiles = RaggedBufferF32.from_array(tiles)
+
+        ids = [
+            list(
+                range(
+                    ragged_allies[i].items()
+                    + ragged_enemies[i].items()
+                    + ragged_minerals[i].items()
+                    + ragged_tiles[i].items()
+                )
+            )
+            for i in range(num_envs)
+        ]
+
+        actors: List[int] = []
+        for i in range(num_envs):
+            actors.extend(list(range(ragged_allies[i].items())))
+
+        batch = ObsBatch(
+            entities={
+                "ally": ragged_allies,
+                # "enemy": ragged_enemies,
+                "mineral": ragged_minerals,
+                # "tile": ragged_tiles,
+            },
+            ids=ids,  # type: ignore
+            action_masks={
+                "act": CategoricalActionMaskBatch(
+                    actors=RaggedBufferI64.from_flattened(
+                        np.array(actors, dtype=np.int64).reshape(-1, 1),
+                        ragged_allies.size1(),
+                    ),
+                    masks=RaggedBufferBool.from_flattened(
+                        action_masks[ally_not_padding] == 1.0, ragged_allies.size1()
+                    ),
+                ),
+            },
+            reward=np.array(rews),
+            done=np.array(dones) == 1.0,
+            end_of_episode_info=infos,
+        )
+        return batch
+
+    def close(self) -> None:
+        # Run all games to completion
+        done: Dict[int, bool] = defaultdict(lambda: False)
+        running = len(self.games)
+        while running > 0:
+            game_actions: List[Any] = []
+            active_games = []
+            for (game_id, player_id, _) in self.games:
+                if not done[game_id]:
+                    active_games.append((game_id, player_id))
+                    game_actions.append(
+                        (game_id, player_id, [(False, 0, [], False, False, False)])
+                    )
+            rest_client.act_batch(game_actions)
+            obs = rest_client.observe_batch(active_games)
+            for o, (game_id, _) in zip(obs, active_games):
+                if o["winner"]:
+                    done[game_id] = True
+                    running -= 1
+
+    def next_map(
+        self, require_default_mothership: bool = False
+    ) -> Optional[Dict[str, Any]]:
+        if self.fair:
+            map = self.fair_map(require_default_mothership)
+        else:
+            map = self.custom_map(
+                self.randomize, self.hardness, require_default_mothership
+            )
+        if map:
+            map["symmetric"] = np.random.rand() < self.symmetric
+        return map
+
+    def fair_map(
+        self, require_default_mothership: bool = False
+    ) -> Optional[Dict[str, Any]]:
+        if self.last_map is None:
+            self.last_map = self.custom_map(
+                self.randomize, self.hardness, require_default_mothership
+            )
+            assert self.last_map is not None
+            return self.last_map
+        else:
+            result = self.last_map
+            self.last_map = None
+            p1 = result["player1Drones"]
+            result["player1Drones"] = result["player2Drones"]
+            result["player2Drones"] = p1
+            return result
+
+    def __len__(self) -> int:
+        return self.num_envs
+
+    def env_cls(cls) -> Type[Environment]:
+        return CodeCraftEnv
+
+
+def dist(x1: float, y1: float, x2: float, y2: float) -> float:
+    dx = x1 - x2
+    dy = y1 - y2
+    return np.sqrt(dx * dx + dy * dy)  # type: ignore
+
+
+def dist2(x1: float, y1: float, x2: float, y2: float) -> float:
+    dx = x1 - x2
+    dy = y1 - y2
+    return dx * dx + dy * dy
+
+
+def map_allied_wealth(
+    randomize: bool, hardness: int, require_default_mothership: bool
+) -> Dict[str, Any]:
+    map_width = 6000
+    map_height = 3750
+    mineral_count = 25
+    angle = 2 * np.pi * np.random.rand()
+    spawn_x = (map_width // 2 - 100) * np.sin(angle)
+    spawn_y = (map_height // 2 - 100) * np.cos(angle)
+
+    return {
+        "mapWidth": map_width,
+        "mapHeight": map_height,
+        "minerals": mineral_count * [(1, 1)],
+        "player1Drones": [
+            drone_dict(
+                spawn_x,
+                spawn_y,
+                constructors=2,
+                storage_modules=4,
+                engines=4,
+                resources=0,
+            )
+        ],
+        "player2Drones": [drone_dict(-spawn_x, -spawn_y, shield_generators=10)],
+    }
+
+
+def drone_dict(
+    x: int,
+    y: int,
+    storage_modules: int = 0,
+    missile_batteries: int = 0,
+    constructors: int = 0,
+    engines: int = 0,
+    shield_generators: int = 0,
+    long_range_missiles: int = 0,
+    resources: int = 0,
+) -> Dict[str, int]:
+    return {
+        "xPos": x,
+        "yPos": y,
+        "resources": resources,
+        "storageModules": storage_modules,
+        "missileBatteries": missile_batteries,
+        "constructors": constructors,
+        "engines": engines,
+        "shieldGenerators": shield_generators,
+        "longRangeMissiles": long_range_missiles,
+    }

--- a/enn_zoo/poetry.lock
+++ b/enn_zoo/poetry.lock
@@ -1,17 +1,36 @@
 [[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.10"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
 name = "cloudpickle"
 version = "2.0.0"
 description = "Extended pickling support for Python objects"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "griddly"
-version = "1.2.16"
+version = "1.2.24"
 description = "Griddly Python Libraries"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -25,7 +44,7 @@ name = "gym"
 version = "0.21.0"
 description = "Gym: A universal API for reinforcement learning environments."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -46,11 +65,19 @@ robotics = ["mujoco_py (>=1.50,<2.0)"]
 toy_text = ["scipy (>=1.4.1)"]
 
 [[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "imageio"
-version = "2.13.1"
+version = "2.13.5"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -72,11 +99,11 @@ tifffile = ["tifffile"]
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.2"
+version = "4.10.1"
 description = "Read metadata from Python packages"
 category = "main"
-optional = true
-python-versions = ">=3.6"
+optional = false
+python-versions = ">=3.7"
 
 [package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
@@ -85,164 +112,245 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "numpy"
-version = "1.21.4"
+version = "1.21.5"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7,<3.11"
 
 [[package]]
+name = "orjson"
+version = "3.6.5"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "pillow"
-version = "8.4.0"
+version = "9.0.0"
 description = "Python Imaging Library (Fork)"
 category = "main"
-optional = true
-python-versions = ">=3.6"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.27.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "types-requests"
+version = "2.27.7"
+description = "Typing stubs for requests"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.7"
+description = "Typing stubs for urllib3"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
 version = "4.0.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "urllib3"
+version = "1.26.8"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
 name = "zipp"
-version = "3.6.0"
+version = "3.7.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
-optional = true
-python-versions = ">=3.6"
+optional = false
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
-[extras]
-griddly = ["griddly"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "d0fc8a4e42e354861f8cb3a432850f46cf697f399e801a2aa2fba941d4e5a5c1"
+content-hash = "4768ae78722111321daea15967a25963ce0aa70d1401512be121634a118acc36"
 
 [metadata.files]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
+    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+]
 cloudpickle = [
     {file = "cloudpickle-2.0.0-py3-none-any.whl", hash = "sha256:6b2df9741d06f43839a3275c4e6632f7df6487a1f181f5f46a052d3c917c3d11"},
     {file = "cloudpickle-2.0.0.tar.gz", hash = "sha256:5cd02f3b417a783ba84a4ec3e290ff7929009fe51f6405423cfccfadd43ba4a4"},
 ]
 griddly = [
-    {file = "griddly-1.2.16-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:484e8ec9f00663bc431a80eb88cbc5023a856836294f138570febebe6760ad8f"},
-    {file = "griddly-1.2.16-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:1807143a50190d454c01d6d411682b69436c9dc3900ee06f8b29f5349ed6b7be"},
-    {file = "griddly-1.2.16-cp36-cp36m-win_amd64.whl", hash = "sha256:9e4a350f50e8b63a75b3ff3b2810a8b9f9fd5be0552f32012adf0ad575fa8339"},
-    {file = "griddly-1.2.16-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:e3adb68fc9b06fdde2acb700e6dca78b4790783943c58162d058af071db21070"},
-    {file = "griddly-1.2.16-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:052b6613e15f827544c6eb37b44409d54618b7621d66895f6301678fbc9baf18"},
-    {file = "griddly-1.2.16-cp37-cp37m-win_amd64.whl", hash = "sha256:4eee8cd85e7e2f3ce56f2818d904eb9f6d1d6af8741d073a4802bd2b6b5ff804"},
-    {file = "griddly-1.2.16-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:79a3c2b103380f043cd084a5d9b3df5d239054b5a97c05015c094a59701eb1d1"},
-    {file = "griddly-1.2.16-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0f67ea041d883afdb7944bf6de9f5978f6741c23c2f8fb29da4382c9d6fe0e69"},
-    {file = "griddly-1.2.16-cp38-cp38-win_amd64.whl", hash = "sha256:4a48b0ba26902c5c48bc56b9a69e87ceb4a06e9354a9820c0ee46feb82d3fe8c"},
-    {file = "griddly-1.2.16-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:9daf00abd75f8536a27ecda43df76cbf902a48dad57d9cf32c0caa912082424a"},
-    {file = "griddly-1.2.16-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:e85cb906417d489d5b614939be59283de0a2cf6c255f5529eb97c5c3c0b332c5"},
-    {file = "griddly-1.2.16-cp39-cp39-win_amd64.whl", hash = "sha256:b47e3a91344549d7ba0450eccba2a5fb1827ea6b98c821a77825438da831de39"},
+    {file = "griddly-1.2.24-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:d10d07573ee04f37fabca3b49a4c81e0ac1aba26c664c1199cf8061c3725ef49"},
+    {file = "griddly-1.2.24-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7336175ac050326b6d7674cda4c9fcf72ee83d55ed33096f4f2ded37bf9572ba"},
+    {file = "griddly-1.2.24-cp37-cp37m-win_amd64.whl", hash = "sha256:b35d9a72506e943ff8ed0ffae33b114e86a458ea4963ce0f2f4333aeb03716c4"},
+    {file = "griddly-1.2.24-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:bd2eeeded2d70b1ede8bb61b73fdf4af0c61b6b39e14d80572d2086f334dc6d9"},
+    {file = "griddly-1.2.24-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:095ab8218189bc0092dfd17e3852edb01ba98ec83fcc1623d7ea06717e0feea6"},
+    {file = "griddly-1.2.24-cp38-cp38-win_amd64.whl", hash = "sha256:d1e80b0f65accfe06c831b27b4045ee4c2b0752d5f43d58a8297e50e510d492f"},
+    {file = "griddly-1.2.24-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:6fde272ff6f861f001c2791b2b4f395964f0265ff67f9f56ce1ef1bc4fd19f68"},
+    {file = "griddly-1.2.24-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:884c3671a133a05ff89019a6576c5c17f593f3743fa7382c154c18c041b44553"},
+    {file = "griddly-1.2.24-cp39-cp39-win_amd64.whl", hash = "sha256:a94290149747ebafffd284a76cbd471059a7100a74c6374edfb7a15f55933dff"},
 ]
 gym = [
     {file = "gym-0.21.0.tar.gz", hash = "sha256:0fd1ce165c754b4017e37a617b097c032b8c3feb8a0394ccc8777c7c50dddff3"},
 ]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
 imageio = [
-    {file = "imageio-2.13.1-py3-none-any.whl", hash = "sha256:2b45f8275bf3f513f80512da540d60268417021d217cac7c384783be0acb42fe"},
-    {file = "imageio-2.13.1.tar.gz", hash = "sha256:d3672d6a676f284c13a89d632b07b441f234caf0748e59271a18464a84172040"},
+    {file = "imageio-2.13.5-py3-none-any.whl", hash = "sha256:a3a18d5d01732557247fba5658d7f75425e97ce49c8fe2cd81bd348f5c71ffb2"},
+    {file = "imageio-2.13.5.tar.gz", hash = "sha256:c7ec2be58e401b6eaa838f8eaf8368ed54b2de4a1b001fe6551644f1a30a843d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
-    {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
+    {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
+    {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
 ]
 numpy = [
-    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f"},
-    {file = "numpy-1.21.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:69077388c5a4b997442b843dbdc3a85b420fb693ec8e33020bb24d647c164fa5"},
-    {file = "numpy-1.21.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e89717274b41ebd568cd7943fc9418eeb49b1785b66031bc8a7f6300463c5898"},
-    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b78ecfa070460104934e2caf51694ccd00f37d5e5dbe76f021b1b0b0d221823"},
-    {file = "numpy-1.21.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:615d4e328af7204c13ae3d4df7615a13ff60a49cb0d9106fde07f541207883ca"},
-    {file = "numpy-1.21.4-cp310-cp310-win_amd64.whl", hash = "sha256:1403b4e2181fc72664737d848b60e65150f272fe5a1c1cbc16145ed43884065a"},
-    {file = "numpy-1.21.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:74b85a17528ca60cf98381a5e779fc0264b4a88b46025e6bcbe9621f46bb3e63"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92aafa03da8658609f59f18722b88f0a73a249101169e28415b4fa148caf7e41"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d95668e727c75b3f5088ec7700e260f90ec83f488e4c0aaccb941148b2cd377"},
-    {file = "numpy-1.21.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5162ec777ba7138906c9c274353ece5603646c6965570d82905546579573f73"},
-    {file = "numpy-1.21.4-cp37-cp37m-win32.whl", hash = "sha256:81225e58ef5fce7f1d80399575576fc5febec79a8a2742e8ef86d7b03beef49f"},
-    {file = "numpy-1.21.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32fe5b12061f6446adcbb32cf4060a14741f9c21e15aaee59a207b6ce6423469"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c449eb870616a7b62e097982c622d2577b3dbc800aaf8689254ec6e0197cbf1e"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e4ed57f45f0aa38beca2a03b6532e70e548faf2debbeb3291cfc9b315d9be8f"},
-    {file = "numpy-1.21.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1247ef28387b7bb7f21caf2dbe4767f4f4175df44d30604d42ad9bd701ebb31f"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34f3456f530ae8b44231c63082c8899fe9c983fd9b108c997c4b1c8c2d435333"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4c9c23158b87ed0e70d9a50c67e5c0b3f75bcf2581a8e34668d4e9d7474d76c6"},
-    {file = "numpy-1.21.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4799be6a2d7d3c33699a6f77201836ac975b2e1b98c2a07f66a38f499cb50ce"},
-    {file = "numpy-1.21.4-cp38-cp38-win32.whl", hash = "sha256:bc988afcea53e6156546e5b2885b7efab089570783d9d82caf1cfd323b0bb3dd"},
-    {file = "numpy-1.21.4-cp38-cp38-win_amd64.whl", hash = "sha256:170b2a0805c6891ca78c1d96ee72e4c3ed1ae0a992c75444b6ab20ff038ba2cd"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:fde96af889262e85aa033f8ee1d3241e32bf36228318a61f1ace579df4e8170d"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4"},
-    {file = "numpy-1.21.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad010846cdffe7ec27e3f933397f8a8d6c801a48634f419e3d075db27acf5880"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c"},
-    {file = "numpy-1.21.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0"},
-    {file = "numpy-1.21.4-cp39-cp39-win32.whl", hash = "sha256:b1e2312f5b8843a3e4e8224b2b48fe16119617b8fc0a54df8f50098721b5bed2"},
-    {file = "numpy-1.21.4-cp39-cp39-win_amd64.whl", hash = "sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8"},
-    {file = "numpy-1.21.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a3deb31bc84f2b42584b8c4001c85d1934dbfb4030827110bc36bfd11509b7bf"},
-    {file = "numpy-1.21.4.zip", hash = "sha256:e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:301e408a052fdcda5cdcf03021ebafc3c6ea093021bf9d1aa47c54d48bdad166"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a7e8f6216f180f3fd4efb73de5d1eaefb5f5a1ee5b645c67333033e39440e63a"},
+    {file = "numpy-1.21.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc7a7d7b0ed72589fd8b8486b9b42a564f10b8762be8bd4d9df94b807af4a089"},
+    {file = "numpy-1.21.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58ca1d7c8aef6e996112d0ce873ac9dfa1eaf4a1196b4ff7ff73880a09923ba7"},
+    {file = "numpy-1.21.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc4b2fb01f1b4ddbe2453468ea0719f4dbb1f5caa712c8b21bb3dd1480cd30d9"},
+    {file = "numpy-1.21.5-cp310-cp310-win_amd64.whl", hash = "sha256:cc1b30205d138d1005adb52087ff45708febbef0e420386f58664f984ef56954"},
+    {file = "numpy-1.21.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:08de8472d9f7571f9d51b27b75e827f5296295fa78817032e84464be8bb905bc"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4fe6a006557b87b352c04596a6e3f12a57d6e5f401d804947bd3188e6b0e0e76"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3d893b0871322eaa2f8c7072cdb552d8e2b27645b7875a70833c31e9274d4611"},
+    {file = "numpy-1.21.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:341dddcfe3b7b6427a28a27baa59af5ad51baa59bfec3264f1ab287aa3b30b13"},
+    {file = "numpy-1.21.5-cp37-cp37m-win32.whl", hash = "sha256:ca9c23848292c6fe0a19d212790e62f398fd9609aaa838859be8459bfbe558aa"},
+    {file = "numpy-1.21.5-cp37-cp37m-win_amd64.whl", hash = "sha256:025b497014bc33fc23897859350f284323f32a2fff7654697f5a5fc2a19e9939"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3a5098df115340fb17fc93867317a947e1dcd978c3888c5ddb118366095851f8"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:311283acf880cfcc20369201bd75da907909afc4666966c7895cbed6f9d2c640"},
+    {file = "numpy-1.21.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b545ebadaa2b878c8630e5bcdb97fc4096e779f335fc0f943547c1c91540c815"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c5562bcc1a9b61960fc8950ade44d00e3de28f891af0acc96307c73613d18f6e"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eed2afaa97ec33b4411995be12f8bdb95c87984eaa28d76cf628970c8a2d689a"},
+    {file = "numpy-1.21.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61bada43d494515d5b122f4532af226fdb5ee08fe5b5918b111279843dc6836a"},
+    {file = "numpy-1.21.5-cp38-cp38-win32.whl", hash = "sha256:7b9d6b14fc9a4864b08d1ba57d732b248f0e482c7b2ff55c313137e3ed4d8449"},
+    {file = "numpy-1.21.5-cp38-cp38-win_amd64.whl", hash = "sha256:dbce7adeb66b895c6aaa1fad796aaefc299ced597f6fbd9ceddb0dd735245354"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:507c05c7a37b3683eb08a3ff993bd1ee1e6c752f77c2f275260533b265ecdb6c"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:00c9fa73a6989895b8815d98300a20ac993c49ac36c8277e8ffeaa3631c0dbbb"},
+    {file = "numpy-1.21.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:69a5a8d71c308d7ef33ef72371c2388a90e3495dbb7993430e674006f94797d5"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2d8adfca843bc46ac199a4645233f13abf2011a0b2f4affc5c37cd552626f27b"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c293d3c0321996cd8ffe84215ffe5d269fd9d1d12c6f4ffe2b597a7c30d3e593"},
+    {file = "numpy-1.21.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c978544be9e04ed12016dd295a74283773149b48f507d69b36f91aa90a643e5"},
+    {file = "numpy-1.21.5-cp39-cp39-win32.whl", hash = "sha256:2a9add27d7fc0fdb572abc3b2486eb3b1395da71e0254c5552b2aad2a18b5441"},
+    {file = "numpy-1.21.5-cp39-cp39-win_amd64.whl", hash = "sha256:1964db2d4a00348b7a60ee9d013c8cb0c566644a589eaa80995126eac3b99ced"},
+    {file = "numpy-1.21.5-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a7c4b701ca418cd39e28ec3b496e6388fe06de83f5f0cb74794fa31cfa384c02"},
+    {file = "numpy-1.21.5.zip", hash = "sha256:6a5928bc6241264dce5ed509e66f33676fc97f464e7a919edc672fb5532221ee"},
+]
+orjson = [
+    {file = "orjson-3.6.5-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:6c444edc073eb69cf85b28851a7a957807a41ce9bb3a9c14eefa8b33030cf050"},
+    {file = "orjson-3.6.5-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:432c6da3d8d4630739f5303dcc45e8029d357b7ff8e70b7239be7bd047df6b19"},
+    {file = "orjson-3.6.5-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:0fa32319072fadf0732d2c1746152f868a1b0f83c8cce2cad4996f5f3ca4e979"},
+    {file = "orjson-3.6.5-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:0d65cc67f2e358712e33bc53810022ef5181c2378a7603249cd0898aa6cd28d4"},
+    {file = "orjson-3.6.5-cp310-none-win_amd64.whl", hash = "sha256:fa8e3d0f0466b7d771a8f067bd8961bc17ca6ea4c89a91cd34d6648e6b1d1e47"},
+    {file = "orjson-3.6.5-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:470596fbe300a7350fd7bbcf94d2647156401ab6465decb672a00e201af1813a"},
+    {file = "orjson-3.6.5-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d2680d9edc98171b0c59e52c1ed964619be5cb9661289c0dd2e667773fa87f15"},
+    {file = "orjson-3.6.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:001962a334e1ab2162d2f695f2770d2383c7ffd2805cec6dbb63ea2ad96bf0ad"},
+    {file = "orjson-3.6.5-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:522c088679c69e0dd2c72f43cd26a9e73df4ccf9ed725ac73c151bbe816fe51a"},
+    {file = "orjson-3.6.5-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:d2b871a745a64f72631b633271577c99da628a9b63e10bd5c9c20706e19fe282"},
+    {file = "orjson-3.6.5-cp37-none-win_amd64.whl", hash = "sha256:51ab01fed3b3e21561f21386a2f86a0415338541938883b6ca095001a3014a3e"},
+    {file = "orjson-3.6.5-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:fc7e62edbc7ece95779a034d9e206d7ba9e2b638cc548fd3a82dc5225f656625"},
+    {file = "orjson-3.6.5-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:0720d60db3fa25956011a573274a269eb37de98070f3bc186582af1222a2d084"},
+    {file = "orjson-3.6.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e169a8876aed7a5bff413c53257ef1fa1d9b68c855eb05d658c4e73ed8dff508"},
+    {file = "orjson-3.6.5-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:331f9a3bdba30a6913ad1d149df08e4837581e3ce92bf614277d84efccaf796f"},
+    {file = "orjson-3.6.5-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:ece5dfe346b91b442590a41af7afe61df0af369195fed13a1b29b96b1ba82905"},
+    {file = "orjson-3.6.5-cp38-none-win_amd64.whl", hash = "sha256:6a5e9eb031b44b7a429c705ca48820371d25b9467c9323b6ae7a712daf15fbef"},
+    {file = "orjson-3.6.5-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:206237fa5e45164a678b12acc02aac7c5b50272f7f31116e1e08f8bcaf654f93"},
+    {file = "orjson-3.6.5-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d5aceeb226b060d11ccb5a84a4cfd760f8024289e3810ec446ef2993a85dbaca"},
+    {file = "orjson-3.6.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80dba3dbc0563c49719e8cc7d1568a5cf738accfcd1aa6ca5e8222b57436e75e"},
+    {file = "orjson-3.6.5-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:443f39bc5e7966880142430ce091e502aea068b38cb9db5f1ffdcfee682bc2d4"},
+    {file = "orjson-3.6.5-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:a06f2dd88323a480ac1b14d5829fb6cdd9b0d72d505fabbfbd394da2e2e07f6f"},
+    {file = "orjson-3.6.5-cp39-none-win_amd64.whl", hash = "sha256:82cb42dbd45a3856dbad0a22b54deb5e90b2567cdc2b8ea6708e0c4fe2e12be3"},
+    {file = "orjson-3.6.5.tar.gz", hash = "sha256:eb3a7d92d783c89df26951ef3e5aca9d96c9c6f2284c752aa3382c736f950597"},
 ]
 pillow = [
-    {file = "Pillow-8.4.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:81f8d5c81e483a9442d72d182e1fb6dcb9723f289a57e8030811bac9ea3fef8d"},
-    {file = "Pillow-8.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f97cfb1e5a392d75dd8b9fd274d205404729923840ca94ca45a0af57e13dbe6"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb9fc393f3c61f9054e1ed26e6fe912c7321af2f41ff49d3f83d05bacf22cc78"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d82cdb63100ef5eedb8391732375e6d05993b765f72cb34311fab92103314649"},
-    {file = "Pillow-8.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62cc1afda735a8d109007164714e73771b499768b9bb5afcbbee9d0ff374b43f"},
-    {file = "Pillow-8.4.0-cp310-cp310-win32.whl", hash = "sha256:e3dacecfbeec9a33e932f00c6cd7996e62f53ad46fbe677577394aaa90ee419a"},
-    {file = "Pillow-8.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:620582db2a85b2df5f8a82ddeb52116560d7e5e6b055095f04ad828d1b0baa39"},
-    {file = "Pillow-8.4.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:1bc723b434fbc4ab50bb68e11e93ce5fb69866ad621e3c2c9bdb0cd70e345f55"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cbcfd54df6caf85cc35264c77ede902452d6df41166010262374155947460c"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70ad9e5c6cb9b8487280a02c0ad8a51581dcbbe8484ce058477692a27c151c0a"},
-    {file = "Pillow-8.4.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25a49dc2e2f74e65efaa32b153527fc5ac98508d502fa46e74fa4fd678ed6645"},
-    {file = "Pillow-8.4.0-cp36-cp36m-win32.whl", hash = "sha256:93ce9e955cc95959df98505e4608ad98281fff037350d8c2671c9aa86bcf10a9"},
-    {file = "Pillow-8.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2e4440b8f00f504ee4b53fe30f4e381aae30b0568193be305256b1462216feff"},
-    {file = "Pillow-8.4.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8c803ac3c28bbc53763e6825746f05cc407b20e4a69d0122e526a582e3b5e153"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8a17b5d948f4ceeceb66384727dde11b240736fddeda54ca740b9b8b1556b29"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1394a6ad5abc838c5cd8a92c5a07535648cdf6d09e8e2d6df916dfa9ea86ead8"},
-    {file = "Pillow-8.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792e5c12376594bfcb986ebf3855aa4b7c225754e9a9521298e460e92fb4a488"},
-    {file = "Pillow-8.4.0-cp37-cp37m-win32.whl", hash = "sha256:d99ec152570e4196772e7a8e4ba5320d2d27bf22fdf11743dd882936ed64305b"},
-    {file = "Pillow-8.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7b7017b61bbcdd7f6363aeceb881e23c46583739cb69a3ab39cb384f6ec82e5b"},
-    {file = "Pillow-8.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d89363f02658e253dbd171f7c3716a5d340a24ee82d38aab9183f7fdf0cdca49"},
-    {file = "Pillow-8.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a0956fdc5defc34462bb1c765ee88d933239f9a94bc37d132004775241a7585"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b7bb9de00197fb4261825c15551adf7605cf14a80badf1761d61e59da347779"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72b9e656e340447f827885b8d7a15fc8c4e68d410dc2297ef6787eec0f0ea409"},
-    {file = "Pillow-8.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5a4532a12314149d8b4e4ad8ff09dde7427731fcfa5917ff16d0291f13609df"},
-    {file = "Pillow-8.4.0-cp38-cp38-win32.whl", hash = "sha256:82aafa8d5eb68c8463b6e9baeb4f19043bb31fefc03eb7b216b51e6a9981ae09"},
-    {file = "Pillow-8.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:066f3999cb3b070a95c3652712cffa1a748cd02d60ad7b4e485c3748a04d9d76"},
-    {file = "Pillow-8.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:5503c86916d27c2e101b7f71c2ae2cddba01a2cf55b8395b0255fd33fa4d1f1a"},
-    {file = "Pillow-8.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4acc0985ddf39d1bc969a9220b51d94ed51695d455c228d8ac29fcdb25810e6e"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b052a619a8bfcf26bd8b3f48f45283f9e977890263e4571f2393ed8898d331b"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:493cb4e415f44cd601fcec11c99836f707bb714ab03f5ed46ac25713baf0ff20"},
-    {file = "Pillow-8.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8831cb7332eda5dc89b21a7bce7ef6ad305548820595033a4b03cf3091235ed"},
-    {file = "Pillow-8.4.0-cp39-cp39-win32.whl", hash = "sha256:5e9ac5f66616b87d4da618a20ab0a38324dbe88d8a39b55be8964eb520021e02"},
-    {file = "Pillow-8.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:3eb1ce5f65908556c2d8685a8f0a6e989d887ec4057326f6c22b24e8a172c66b"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:ddc4d832a0f0b4c52fff973a0d44b6c99839a9d016fe4e6a1cb8f3eea96479c2"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a3e5ddc44c14042f0844b8cf7d2cd455f6cc80fd7f5eefbe657292cf601d9ad"},
-    {file = "Pillow-8.4.0-pp36-pypy36_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70e94281588ef053ae8998039610dbd71bc509e4acbc77ab59d7d2937b10698"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:3862b7256046fcd950618ed22d1d60b842e3a40a48236a5498746f21189afbbc"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4901622493f88b1a29bd30ec1a2f683782e57c3c16a2dbc7f2595ba01f639df"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84c471a734240653a0ec91dec0996696eea227eafe72a33bd06c92697728046b"},
-    {file = "Pillow-8.4.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:244cf3b97802c34c41905d22810846802a3329ddcb93ccc432870243211c79fc"},
-    {file = "Pillow-8.4.0.tar.gz", hash = "sha256:b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed"},
+    {file = "Pillow-9.0.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:113723312215b25c22df1fdf0e2da7a3b9c357a7d24a93ebbe80bfda4f37a8d4"},
+    {file = "Pillow-9.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bb47a548cea95b86494a26c89d153fd31122ed65255db5dcbc421a2d28eb3379"},
+    {file = "Pillow-9.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31b265496e603985fad54d52d11970383e317d11e18e856971bdbb86af7242a4"},
+    {file = "Pillow-9.0.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d154ed971a4cc04b93a6d5b47f37948d1f621f25de3e8fa0c26b2d44f24e3e8f"},
+    {file = "Pillow-9.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80fe92813d208ce8aa7d76da878bdc84b90809f79ccbad2a288e9bcbeac1d9bd"},
+    {file = "Pillow-9.0.0-cp310-cp310-win32.whl", hash = "sha256:d5dcea1387331c905405b09cdbfb34611050cc52c865d71f2362f354faee1e9f"},
+    {file = "Pillow-9.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:52abae4c96b5da630a8b4247de5428f593465291e5b239f3f843a911a3cf0105"},
+    {file = "Pillow-9.0.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:72c3110228944019e5f27232296c5923398496b28be42535e3b2dc7297b6e8b6"},
+    {file = "Pillow-9.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97b6d21771da41497b81652d44191489296555b761684f82b7b544c49989110f"},
+    {file = "Pillow-9.0.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72f649d93d4cc4d8cf79c91ebc25137c358718ad75f99e99e043325ea7d56100"},
+    {file = "Pillow-9.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7aaf07085c756f6cb1c692ee0d5a86c531703b6e8c9cae581b31b562c16b98ce"},
+    {file = "Pillow-9.0.0-cp37-cp37m-win32.whl", hash = "sha256:03b27b197deb4ee400ed57d8d4e572d2d8d80f825b6634daf6e2c18c3c6ccfa6"},
+    {file = "Pillow-9.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:a09a9d4ec2b7887f7a088bbaacfd5c07160e746e3d47ec5e8050ae3b2a229e9f"},
+    {file = "Pillow-9.0.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:490e52e99224858f154975db61c060686df8a6b3f0212a678e5d2e2ce24675c9"},
+    {file = "Pillow-9.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:500d397ddf4bbf2ca42e198399ac13e7841956c72645513e8ddf243b31ad2128"},
+    {file = "Pillow-9.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ebd8b9137630a7bbbff8c4b31e774ff05bbb90f7911d93ea2c9371e41039b52"},
+    {file = "Pillow-9.0.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd0e5062f11cb3e730450a7d9f323f4051b532781026395c4323b8ad055523c4"},
+    {file = "Pillow-9.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f3b4522148586d35e78313db4db0df4b759ddd7649ef70002b6c3767d0fdeb7"},
+    {file = "Pillow-9.0.0-cp38-cp38-win32.whl", hash = "sha256:0b281fcadbb688607ea6ece7649c5d59d4bbd574e90db6cd030e9e85bde9fecc"},
+    {file = "Pillow-9.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:b5050d681bcf5c9f2570b93bee5d3ec8ae4cf23158812f91ed57f7126df91762"},
+    {file = "Pillow-9.0.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:c2067b3bb0781f14059b112c9da5a91c80a600a97915b4f48b37f197895dd925"},
+    {file = "Pillow-9.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2d16b6196fb7a54aff6b5e3ecd00f7c0bab1b56eee39214b2b223a9d938c50af"},
+    {file = "Pillow-9.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98cb63ca63cb61f594511c06218ab4394bf80388b3d66cd61d0b1f63ee0ea69f"},
+    {file = "Pillow-9.0.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bc462d24500ba707e9cbdef436c16e5c8cbf29908278af053008d9f689f56dee"},
+    {file = "Pillow-9.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3586e12d874ce2f1bc875a3ffba98732ebb12e18fb6d97be482bd62b56803281"},
+    {file = "Pillow-9.0.0-cp39-cp39-win32.whl", hash = "sha256:68e06f8b2248f6dc8b899c3e7ecf02c9f413aab622f4d6190df53a78b93d97a5"},
+    {file = "Pillow-9.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:6579f9ba84a3d4f1807c4aab4be06f373017fc65fff43498885ac50a9b47a553"},
+    {file = "Pillow-9.0.0-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:47f5cf60bcb9fbc46011f75c9b45a8b5ad077ca352a78185bd3e7f1d294b98bb"},
+    {file = "Pillow-9.0.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fd8053e1f8ff1844419842fd474fc359676b2e2a2b66b11cc59f4fa0a301315"},
+    {file = "Pillow-9.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c5439bfb35a89cac50e81c751317faea647b9a3ec11c039900cd6915831064d"},
+    {file = "Pillow-9.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:95545137fc56ce8c10de646074d242001a112a92de169986abd8c88c27566a05"},
+    {file = "Pillow-9.0.0.tar.gz", hash = "sha256:ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -279,11 +387,27 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
+requests = [
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+types-requests = [
+    {file = "types-requests-2.27.7.tar.gz", hash = "sha256:f38bd488528cdcbce5b01dc953972f3cead0d060cfd9ee35b363066c25bab13c"},
+    {file = "types_requests-2.27.7-py3-none-any.whl", hash = "sha256:2e0e100dd489f83870d4f61949d3a7eae4821e7bfbf46c57e463c38f92d473d4"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.7.tar.gz", hash = "sha256:cfd1fbbe4ba9a605ed148294008aac8a7b8b7472651d1cc357d507ae5962e3d2"},
+    {file = "types_urllib3-1.26.7-py3-none-any.whl", hash = "sha256:3adcf2cb5981809091dbff456e6999fe55f201652d8c360f99997de5ac2f556e"},
+]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
+urllib3 = [
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+]
 zipp = [
-    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
-    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
 ]

--- a/enn_zoo/pyproject.toml
+++ b/enn_zoo/pyproject.toml
@@ -7,6 +7,9 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 griddly = {version = "^1.2.21"}
+requests = "^2.27.1"
+orjson = "^3.6.5"
+types-requests = "^2.27.7"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/entity_gym/pyproject.toml
+++ b/entity_gym/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-ragged-buffer = "^0.3.3"
+ragged-buffer = "^0.3.4"
 msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-optuna.*]
 ignore_missing_imports = True
+[mypy-orjson.*]
+ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,7 +58,7 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "autopage"
-version = "0.4.0"
+version = "0.5.0"
 description = "A library to provide automatic paging for console output"
 category = "main"
 optional = false
@@ -98,11 +98,11 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "cachetools"
-version = "4.2.4"
+version = "5.0.0"
 description = "Extensible memoizing collections and decorators"
 category = "main"
 optional = false
-python-versions = "~=3.5"
+python-versions = "~=3.7"
 
 [[package]]
 name = "certifi"
@@ -262,7 +262,7 @@ msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
 numpy = "^1.21.4"
 optuna = "^2.10.0"
-ragged-buffer = "^0.3.3"
+ragged-buffer = "^0.3.4"
 rogue_net = {path = "../rogue_net", develop = true}
 tensorboard = "^2.7.0"
 tqdm = "^4.62.3"
@@ -283,6 +283,9 @@ develop = true
 
 [package.dependencies]
 griddly = "^1.2.21"
+orjson = "^3.6.5"
+requests = "^2.27.1"
+types-requests = "^2.27.7"
 
 [package.source]
 type = "directory"
@@ -300,7 +303,7 @@ develop = true
 [package.dependencies]
 msgpack = "^1.0.3"
 msgpack-numpy = "^0.4.7"
-ragged-buffer = "^0.3.3"
+ragged-buffer = "^0.3.4"
 
 [package.source]
 type = "directory"
@@ -331,14 +334,14 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""
 
 [[package]]
 name = "google-auth"
-version = "2.3.3"
+version = "2.4.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
 
 [package.dependencies]
-cachetools = ">=2.0.0,<5.0"
+cachetools = ">=2.0.0,<6.0"
 pyasn1-modules = ">=0.2.1"
 rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
 six = ">=1.9.0"
@@ -376,7 +379,7 @@ docs = ["sphinx"]
 
 [[package]]
 name = "griddly"
-version = "1.2.24"
+version = "1.2.25"
 description = "Griddly Python Libraries"
 category = "main"
 optional = false
@@ -437,7 +440,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "imageio"
-version = "2.13.5"
+version = "2.14.0"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
 category = "main"
 optional = false
@@ -462,7 +465,7 @@ tifffile = ["tifffile"]
 
 [[package]]
 name = "importlib-metadata"
-version = "4.10.0"
+version = "4.10.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -515,7 +518,7 @@ toml = {version = ">=0.10.2", markers = "python_version > \"3.6\""}
 
 [[package]]
 name = "ipython"
-version = "7.31.0"
+version = "7.31.1"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
@@ -706,6 +709,14 @@ integration = ["chainer (>=5.0.0)", "cma", "lightgbm", "mlflow", "wandb", "mpi4p
 optional = ["bokeh (<2.0.0)", "matplotlib (>=3.0.0)", "pandas", "plotly (>=4.0.0)", "redis", "scikit-learn (>=0.24.2,<1.0.0)"]
 testing = ["bokeh (<2.0.0)", "chainer (>=5.0.0)", "cma", "fakeredis", "lightgbm", "matplotlib (>=3.0.0)", "mlflow", "mpi4py", "mxnet", "pandas", "plotly (>=4.0.0)", "pytest", "scikit-learn (>=0.24.2,<1.0.0)", "scikit-optimize", "xgboost", "tensorflow", "tensorflow-datasets", "pytorch-ignite", "pytorch-lightning (>=1.0.2)", "skorch", "catalyst (>=21.3)", "torchaudio (==0.8.0)", "allennlp (>=2.2.0,<2.7.0)", "fastai", "botorch (>=0.4.0)", "torch (==1.8.0+cpu)", "torchvision (==0.9.0+cpu)", "torch (==1.8.0)", "torchvision (==0.9.0)"]
 tests = ["fakeredis", "pytest"]
+
+[[package]]
+name = "orjson"
+version = "3.6.6"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+category = "main"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "packaging"
@@ -912,7 +923,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.6"
+version = "3.0.7"
 description = "Python parsing module"
 category = "main"
 optional = false
@@ -988,7 +999,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "ragged-buffer"
-version = "0.3.3"
+version = "0.3.4"
 description = ""
 category = "main"
 optional = false
@@ -1040,7 +1051,7 @@ python-versions = ">=3.7.1,<3.10"
 develop = true
 
 [package.dependencies]
-ragged-buffer = "^0.3.3"
+ragged-buffer = "^0.3.4"
 
 [package.source]
 type = "directory"
@@ -1070,7 +1081,7 @@ numpy = ">=1.16.5,<1.23.0"
 
 [[package]]
 name = "sentry-sdk"
-version = "1.5.2"
+version = "1.5.3"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -1124,7 +1135,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.29"
+version = "1.4.31"
 description = "Database Abstraction Library"
 category = "main"
 optional = false
@@ -1177,7 +1188,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 
 [[package]]
 name = "tensorboard"
-version = "2.7.0"
+version = "2.8.0"
 description = "TensorBoard lets you watch Tensors Flow"
 category = "main"
 optional = false
@@ -1268,6 +1279,25 @@ name = "typed-ast"
 version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-requests"
+version = "2.27.7"
+description = "Typing stubs for requests"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.7"
+description = "Typing stubs for urllib3"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1397,8 +1427,8 @@ attrs = [
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 autopage = [
-    {file = "autopage-0.4.0-py3-none-any.whl", hash = "sha256:9b8c9c160bfbf3e6e47953009bf1fe432aee5f37bcaf7fecb5b5ac4e265d4882"},
-    {file = "autopage-0.4.0.tar.gz", hash = "sha256:18f511d8ef2e4d3cc22a986d345eab0e03f95b9fa80b74ca63b7fb001551dc42"},
+    {file = "autopage-0.5.0-py3-none-any.whl", hash = "sha256:57232860f28a1867cdd54b5ea510e292c53d6dfb613f781c5120200666550b06"},
+    {file = "autopage-0.5.0.tar.gz", hash = "sha256:5305b43cc0798170d7124e5a2feecf969e45f4a0baf75cb351138114eaf76b83"},
 ]
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
@@ -1409,8 +1439,8 @@ black = [
     {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 cachetools = [
-    {file = "cachetools-4.2.4-py3-none-any.whl", hash = "sha256:92971d3cb7d2a97efff7c7bb1657f21a8f5fb309a37530537c71b1774189f2d1"},
-    {file = "cachetools-4.2.4.tar.gz", hash = "sha256:89ea6f1b638d5a73a4f9226be57ac5e4f399d22770b92355f92dcb0f7f001693"},
+    {file = "cachetools-5.0.0-py3-none-any.whl", hash = "sha256:8fecd4203a38af17928be7b90689d8083603073622229ca7077b72d8e5a976e4"},
+    {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1472,8 +1502,8 @@ gitpython = [
     {file = "GitPython-3.1.26.tar.gz", hash = "sha256:fc8868f63a2e6d268fb25f481995ba185a85a66fcad126f039323ff6635669ee"},
 ]
 google-auth = [
-    {file = "google-auth-2.3.3.tar.gz", hash = "sha256:d83570a664c10b97a1dc6f8df87e5fdfff012f48f62be131e449c20dfc32630e"},
-    {file = "google_auth-2.3.3-py2.py3-none-any.whl", hash = "sha256:a348a50b027679cb7dae98043ac8dbcc1d7951f06d8387496071a1e05a2465c0"},
+    {file = "google-auth-2.4.0.tar.gz", hash = "sha256:ef6f4827f6a3f9c5ff884616e2ba779acb5d690486fb70ca5e3091ed85ad932a"},
+    {file = "google_auth-2.4.0-py2.py3-none-any.whl", hash = "sha256:d1fad279d9d97e7d6b4a09a53e851ab2ee6d36d5c19547354a3f47a8a6ae41b9"},
 ]
 google-auth-oauthlib = [
     {file = "google-auth-oauthlib-0.4.6.tar.gz", hash = "sha256:a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a"},
@@ -1537,15 +1567,15 @@ greenlet = [
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
 griddly = [
-    {file = "griddly-1.2.24-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:d10d07573ee04f37fabca3b49a4c81e0ac1aba26c664c1199cf8061c3725ef49"},
-    {file = "griddly-1.2.24-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7336175ac050326b6d7674cda4c9fcf72ee83d55ed33096f4f2ded37bf9572ba"},
-    {file = "griddly-1.2.24-cp37-cp37m-win_amd64.whl", hash = "sha256:b35d9a72506e943ff8ed0ffae33b114e86a458ea4963ce0f2f4333aeb03716c4"},
-    {file = "griddly-1.2.24-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:bd2eeeded2d70b1ede8bb61b73fdf4af0c61b6b39e14d80572d2086f334dc6d9"},
-    {file = "griddly-1.2.24-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:095ab8218189bc0092dfd17e3852edb01ba98ec83fcc1623d7ea06717e0feea6"},
-    {file = "griddly-1.2.24-cp38-cp38-win_amd64.whl", hash = "sha256:d1e80b0f65accfe06c831b27b4045ee4c2b0752d5f43d58a8297e50e510d492f"},
-    {file = "griddly-1.2.24-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:6fde272ff6f861f001c2791b2b4f395964f0265ff67f9f56ce1ef1bc4fd19f68"},
-    {file = "griddly-1.2.24-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:884c3671a133a05ff89019a6576c5c17f593f3743fa7382c154c18c041b44553"},
-    {file = "griddly-1.2.24-cp39-cp39-win_amd64.whl", hash = "sha256:a94290149747ebafffd284a76cbd471059a7100a74c6374edfb7a15f55933dff"},
+    {file = "griddly-1.2.25-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:2e75c4ad364c7d489bbea88072d085960668a415ccad0a3566062415b1b8a5c7"},
+    {file = "griddly-1.2.25-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:78a85cda7ef687a59b3c26169f32b1bcfa13b19c4ddf0b52338eb703c9e2810d"},
+    {file = "griddly-1.2.25-cp37-cp37m-win_amd64.whl", hash = "sha256:5c08787c0a2af1ff7948878173c8f9493dad6c8f88f7c4c7cd3a20b3aebfafd8"},
+    {file = "griddly-1.2.25-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:432d4aa9f8c5ffcbe69bf211bb13c7526852b1cc020a6cac3ee02fcd877e6e17"},
+    {file = "griddly-1.2.25-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:c7e8f54e1a1be624db331a7e2f2df7186550f4dd523f46284911a34323cc335f"},
+    {file = "griddly-1.2.25-cp38-cp38-win_amd64.whl", hash = "sha256:95211f848d8ecf1504b24761ccc1b8413f329cfd8062ef4ab05ce0345dfc9156"},
+    {file = "griddly-1.2.25-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:91e630abe1d581a483c3f08288249821ec2d36bbd0fde7ee0f3e16cff479f7f0"},
+    {file = "griddly-1.2.25-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:5da6ba0cf13a4a75b51424e88aabce562588c5da1199b2d2e415bb4fedc2bfbb"},
+    {file = "griddly-1.2.25-cp39-cp39-win_amd64.whl", hash = "sha256:9dd0e1069a31879d787ab1b49664937b300bc5974a34c33b4c2dd27c524efa38"},
 ]
 grpcio = [
     {file = "grpcio-1.43.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:a4e786a8ee8b30b25d70ee52cda6d1dbba2a8ca2f1208d8e20ed8280774f15c8"},
@@ -1601,12 +1631,12 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 imageio = [
-    {file = "imageio-2.13.5-py3-none-any.whl", hash = "sha256:a3a18d5d01732557247fba5658d7f75425e97ce49c8fe2cd81bd348f5c71ffb2"},
-    {file = "imageio-2.13.5.tar.gz", hash = "sha256:c7ec2be58e401b6eaa838f8eaf8368ed54b2de4a1b001fe6551644f1a30a843d"},
+    {file = "imageio-2.14.0-py3-none-any.whl", hash = "sha256:af6c7c89947ee9d81eab2caee3726f61e1a0d861e87e856904868d0fe7c0aa15"},
+    {file = "imageio-2.14.0.tar.gz", hash = "sha256:1a612b46c24805115701ed7c4e1f2d7feb53bb615d52bfef9713a6836e997bb1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.10.0-py3-none-any.whl", hash = "sha256:b7cf7d3fef75f1e4c80a96ca660efbd51473d7e8f39b5ab9210febc7809012a4"},
-    {file = "importlib_metadata-4.10.0.tar.gz", hash = "sha256:92a8b58ce734b2a4494878e0ecf7d79ccd7a128b5fc6014c401e0b61f006f0f6"},
+    {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
+    {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
@@ -1620,8 +1650,8 @@ ipdb = [
     {file = "ipdb-0.13.9.tar.gz", hash = "sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5"},
 ]
 ipython = [
-    {file = "ipython-7.31.0-py3-none-any.whl", hash = "sha256:4c4234cdcc6b8f87c5b5c7af9899aa696ac5cfcf0e9f6d0688018bbee5c73bce"},
-    {file = "ipython-7.31.0.tar.gz", hash = "sha256:346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3"},
+    {file = "ipython-7.31.1-py3-none-any.whl", hash = "sha256:55df3e0bd0f94e715abd968bedd89d4e8a7bce4bf498fb123fed4f5398fea874"},
+    {file = "ipython-7.31.1.tar.gz", hash = "sha256:b5548ec5329a4bcf054a5deed5099b0f9622eb9ea51aaa7104d215fece201d8c"},
 ]
 jedi = [
     {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
@@ -1636,12 +1666,28 @@ markdown = [
     {file = "Markdown-3.3.6.tar.gz", hash = "sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006"},
 ]
 markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
+    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1650,14 +1696,27 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1667,6 +1726,12 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1783,6 +1848,28 @@ oauthlib = [
 optuna = [
     {file = "optuna-2.10.0-py3-none-any.whl", hash = "sha256:457ff8b12b459dc1eeb0178389ff9e5c4da41764cc91152fe324bfd56f88d43f"},
     {file = "optuna-2.10.0.tar.gz", hash = "sha256:04c3100a4fe88a71dc72f69d8a10ec9db7c9a0c884feaf932b68632b00686a8d"},
+]
+orjson = [
+    {file = "orjson-3.6.6-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:e4a7cad6c63306318453980d302c7c0b74c0cc290dd1f433bbd7d31a5af90cf1"},
+    {file = "orjson-3.6.6-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:e533941dca4a0530a876de32e54bf2fd3269cdec3751aebde7bfb5b5eba98e74"},
+    {file = "orjson-3.6.6-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:3b636753ae34d4619b11ea7d664a2f1e87e55e9738e5123e12bcce22acae9d13"},
+    {file = "orjson-3.6.6-cp310-none-win_amd64.whl", hash = "sha256:78a10295ed048fd916c6584d6d27c232eae805a43e7c14be56e3745f784f0eb6"},
+    {file = "orjson-3.6.6-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:82b4f9fb2af7799b52932a62eac484083f930d5519560d6f64b24d66a368d03f"},
+    {file = "orjson-3.6.6-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:a0033d07309cc7d8b8c4bc5d42f0dd4422b53ceb91dee9f4086bb2afa70b7772"},
+    {file = "orjson-3.6.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b321f99473116ab7c7c028377372f7b4adba4029aaca19cd567e83898f55579"},
+    {file = "orjson-3.6.6-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:00b333a41392bd07a8603c42670547dbedf9b291485d773f90c6470eff435608"},
+    {file = "orjson-3.6.6-cp37-none-win_amd64.whl", hash = "sha256:8d4fd3bdee65a81f2b79c50937d4b3c054e1e6bfa3fc72ed018a97c0c7c3d521"},
+    {file = "orjson-3.6.6-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:954c9f8547247cd7a8c91094ff39c9fe314b5eaeaec90b7bfb7384a4108f416f"},
+    {file = "orjson-3.6.6-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:74e5aed657ed0b91ef05d44d6a26d3e3e12ce4d2d71f75df41a477b05878c4a9"},
+    {file = "orjson-3.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4008a5130e6e9c33abaa95e939e0e755175da10745740aa6968461b2f16830e2"},
+    {file = "orjson-3.6.6-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:b464546718a940b48d095a98df4c04808bfa6c8706fe751fc3f9390bc2f82643"},
+    {file = "orjson-3.6.6-cp38-none-win_amd64.whl", hash = "sha256:f10a800f4e5a4aab52076d4628e9e4dab9370bdd9d8ea254ebfde846b653ab25"},
+    {file = "orjson-3.6.6-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:8010d2610cfab721725ef14d578c7071e946bbdae63322d8f7b49061cf3fde8d"},
+    {file = "orjson-3.6.6-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:8dca67a4855e1e0f9a2ea0386e8db892708522e1171dc0ddf456932288fbae63"},
+    {file = "orjson-3.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af065d60523139b99bd35b839c7a2d8c5da55df8a8c4402d2eb6cdc07fa7a624"},
+    {file = "orjson-3.6.6-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:ec1221ad78f94d27b162a1d35672b62ef86f27f0e4c2b65051edb480cc86b286"},
+    {file = "orjson-3.6.6-cp39-none-win_amd64.whl", hash = "sha256:afed2af55eeda1de6b3f1cbc93431981b19d380fcc04f6ed86e74c1913070304"},
+    {file = "orjson-3.6.6.tar.gz", hash = "sha256:55dd988400fa7fbe0e31407c683f5aaab013b5bd967167b8fe058186773c4d6c"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -1964,8 +2051,8 @@ pygments = [
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
-    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
 ]
 pyperclip = [
     {file = "pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},
@@ -2023,18 +2110,18 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 ragged-buffer = [
-    {file = "ragged_buffer-0.3.3-cp310-none-win_amd64.whl", hash = "sha256:080504d9e1fbf77c96ea2cb656ee2a0112f1f249b9f56503843c2d4d8fbf0fae"},
-    {file = "ragged_buffer-0.3.3-cp36-none-win_amd64.whl", hash = "sha256:bdff4df17d0b639748bb6e58027e4e4ce2118780e32204b2a2e35b979261863a"},
-    {file = "ragged_buffer-0.3.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:dfc3b8ad24f5e42a59ab9227c5312b1a5d0dd44763d8172c1eeb98c453b3228c"},
-    {file = "ragged_buffer-0.3.3-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:1daa672f7baad60e208f3f60d1b2d686308812695dc992f9ce1f630d9a08dbdb"},
-    {file = "ragged_buffer-0.3.3-cp37-none-win_amd64.whl", hash = "sha256:cf5a1a979a28ab2d98da47d0e9c0d5b24ff259fe479a67894ad84832cea876e6"},
-    {file = "ragged_buffer-0.3.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:c7c52e3ee809fde41e8ad61f6a58a63384601e7994d1ae3045cb5694fb6762c3"},
-    {file = "ragged_buffer-0.3.3-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:55f9664a0d141af3e451e9978ee4946366e6fd203bb44b23227733089f571be1"},
-    {file = "ragged_buffer-0.3.3-cp38-none-win_amd64.whl", hash = "sha256:15eedbbe36f74bde199c6efae8fa1961b00f51d09a621aa733d634f4c84ccd55"},
-    {file = "ragged_buffer-0.3.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:c869c9fae1ff2584b57d259a54328729fbf82430aa8fde5cb489d2b908870ee8"},
-    {file = "ragged_buffer-0.3.3-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:d05e5bc19c5d073f9f37ff060fa337d3cf3c391a3ecb82770dd632bdeb93244a"},
-    {file = "ragged_buffer-0.3.3-cp39-none-win_amd64.whl", hash = "sha256:0fe1b5884103c0aab613922d108bb33b880a20563cdaea16e92ad2f40484b046"},
-    {file = "ragged_buffer-0.3.3.tar.gz", hash = "sha256:b16b6a871458ea1be8b69a74713a64ed67245c6e0936707f9fe14d2203e5f1d8"},
+    {file = "ragged_buffer-0.3.4-cp310-none-win_amd64.whl", hash = "sha256:12e0037a65abbba354c5f046cf71aefc704a738bcaf691135e2a051a298a3030"},
+    {file = "ragged_buffer-0.3.4-cp36-none-win_amd64.whl", hash = "sha256:e40da532b8487bedece96d4a334660feff81a60ce949ccdb4c6b276162627dc1"},
+    {file = "ragged_buffer-0.3.4-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:7cf7199bbf7b96814af36b3ffd23a0df0ccada27a5dece089e6fcf7557015f58"},
+    {file = "ragged_buffer-0.3.4-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:a5cef215b2ebfd5d55c3d49c03aed27f0311565ebb8385224d8d193b9688cc07"},
+    {file = "ragged_buffer-0.3.4-cp37-none-win_amd64.whl", hash = "sha256:3d07026946845ace2d1af352795df0dcc546415dbc3a5960f4ffdd89884015e0"},
+    {file = "ragged_buffer-0.3.4-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:4232a0e0722637873cf59df4883f6857f381a610c52e52f062b255850530ec06"},
+    {file = "ragged_buffer-0.3.4-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:f54cb2f5c659c7e33c538671400b235482b9968cbe81ba04ff15c50ae52e5d21"},
+    {file = "ragged_buffer-0.3.4-cp38-none-win_amd64.whl", hash = "sha256:570768e2d2909249802cd5b6d760001e55ffdb88d1d4bccb11921cf895a9eaab"},
+    {file = "ragged_buffer-0.3.4-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:a2fa864a9f570c6822e4e5cfd79b3c043b9923bdc63bc7cc72dd2ae596e82558"},
+    {file = "ragged_buffer-0.3.4-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:0574bbe61d8d0daa7157adf3325f4de0acb9672c2ebd8b3ad6c517a9ce67fee5"},
+    {file = "ragged_buffer-0.3.4-cp39-none-win_amd64.whl", hash = "sha256:0f4d5ef52068aaf7b740f66a68647fe5f2b30b9cad2851b308d723950f757ad9"},
+    {file = "ragged_buffer-0.3.4.tar.gz", hash = "sha256:7eddcc9735fa5505c793371a75d9054b81ec3ddfcad9e3622f6e4b0673f8ec1c"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
@@ -2082,8 +2169,8 @@ scipy = [
     {file = "scipy-1.7.3.tar.gz", hash = "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.5.2.tar.gz", hash = "sha256:7bbaa32bba806ec629962f207b597e86831c7ee2c1f287c21ba7de7fea9a9c46"},
-    {file = "sentry_sdk-1.5.2-py2.py3-none-any.whl", hash = "sha256:2cec50166bcb67e1965f8073541b2321e3864cd6fd42a526bcde9f0c4e4cc3f8"},
+    {file = "sentry-sdk-1.5.3.tar.gz", hash = "sha256:141da032f0fa4c56f9af6b361fda57360af1789576285bd1944561f9c274f9c0"},
+    {file = "sentry_sdk-1.5.3-py2.py3-none-any.whl", hash = "sha256:9aeff2a47f4038460296b920bf4d269284e8454e1c67547ee002ccafd9c2442b"},
 ]
 shortuuid = [
     {file = "shortuuid-1.0.8-py3-none-any.whl", hash = "sha256:44a7a86bcf24dbaba2e626cf80c779926b7c3a0d31a3a013e0d3cd1077707d23"},
@@ -2098,42 +2185,42 @@ smmap = [
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.4.29-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:da64423c05256f4ab8c0058b90202053b201cbe3a081f3a43eb590cd554395ab"},
-    {file = "SQLAlchemy-1.4.29-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0fc4eec2f46b40bdd42112b3be3fbbf88e194bcf02950fbb88bcdc1b32f07dc7"},
-    {file = "SQLAlchemy-1.4.29-cp27-cp27m-win32.whl", hash = "sha256:101d2e100ba9182c9039699588e0b2d833c54b3bad46c67c192159876c9f27ea"},
-    {file = "SQLAlchemy-1.4.29-cp27-cp27m-win_amd64.whl", hash = "sha256:ceac84dd9abbbe115e8be0c817bed85d9fa639b4d294e7817f9e61162d5f766c"},
-    {file = "SQLAlchemy-1.4.29-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:15b65887b6c324cad638c7671cb95985817b733242a7eb69edd7cdf6953be1e0"},
-    {file = "SQLAlchemy-1.4.29-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:78abc507d17753ed434b6cc0c0693126279723d5656d9775bfcac966a99a899b"},
-    {file = "SQLAlchemy-1.4.29-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb8c993706e86178ce15a6b86a335a2064f52254b640e7f53365e716423d33f4"},
-    {file = "SQLAlchemy-1.4.29-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:804e22d5b6165a4f3f019dd9c94bec5687de985a9c54286b93ded9f7846b8c82"},
-    {file = "SQLAlchemy-1.4.29-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56d9d62021946263d4478c9ca012fbd1805f10994cb615c88e7bfd1ae14604d8"},
-    {file = "SQLAlchemy-1.4.29-cp310-cp310-win32.whl", hash = "sha256:027f356c727db24f3c75828c7feb426f87ce1241242d08958e454bd025810660"},
-    {file = "SQLAlchemy-1.4.29-cp310-cp310-win_amd64.whl", hash = "sha256:debaf09a823061f88a8dee04949814cf7e82fb394c5bca22c780cb03172ca23b"},
-    {file = "SQLAlchemy-1.4.29-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:dc27dcc6c72eb38be7f144e9c2c4372d35a3684d3a6dd43bd98c1238358ee17c"},
-    {file = "SQLAlchemy-1.4.29-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4ddd4f2e247128c58bb3dd4489922874afce157d2cff0b2295d67fcd0f22494"},
-    {file = "SQLAlchemy-1.4.29-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9ce960a1dc60524136cf6f75621588e2508a117e04a6e3eedb0968bd13b8c824"},
-    {file = "SQLAlchemy-1.4.29-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5919e647e1d4805867ea556ed4967c68b4d8b266059fa35020dbaed8ffdd60f3"},
-    {file = "SQLAlchemy-1.4.29-cp36-cp36m-win32.whl", hash = "sha256:886359f734b95ad1ef443b13bb4518bcade4db4f9553c9ce33d6d04ebda8d44e"},
-    {file = "SQLAlchemy-1.4.29-cp36-cp36m-win_amd64.whl", hash = "sha256:e9cc6d844e24c307c3272677982a9b33816aeb45e4977791c3bdd47637a8d810"},
-    {file = "SQLAlchemy-1.4.29-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:5e9cd33459afa69c88fa648e803d1f1245e3caa60bfe8b80a9595e5edd3bda9c"},
-    {file = "SQLAlchemy-1.4.29-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eeaebceb24b46e884c4ad3c04f37feb178b81f6ce720af19bfa2592ca32fdef7"},
-    {file = "SQLAlchemy-1.4.29-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e89347d3bd2ef873832b47e85f4bbd810a5e626c5e749d90a07638da100eb1c8"},
-    {file = "SQLAlchemy-1.4.29-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a717c2e70fd1bb477161c4cc85258e41d978584fbe5522613618195f7e87d9b"},
-    {file = "SQLAlchemy-1.4.29-cp37-cp37m-win32.whl", hash = "sha256:f74d6c05d2d163464adbdfbc1ab85048cc15462ff7d134b8aed22bd521e1faa5"},
-    {file = "SQLAlchemy-1.4.29-cp37-cp37m-win_amd64.whl", hash = "sha256:621854dbb4d2413c759a5571564170de45ef37299df52e78e62b42e2880192e1"},
-    {file = "SQLAlchemy-1.4.29-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f3909194751bb6cb7c5511dd18bcf77e6e3f0b31604ed4004dffa9461f71e737"},
-    {file = "SQLAlchemy-1.4.29-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd49d21d1f03c81fbec9080ecdc4486d5ddda67e7fbb75ebf48294465c022cdc"},
-    {file = "SQLAlchemy-1.4.29-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e5f6959466a42b6569774c257e55f9cd85200d5b0ba09f0f5d8b5845349c5822"},
-    {file = "SQLAlchemy-1.4.29-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0072f9887aabe66db23f818bbe950cfa1b6127c5cb769b00bcc07935b3adb0ad"},
-    {file = "SQLAlchemy-1.4.29-cp38-cp38-win32.whl", hash = "sha256:ad618d687d26d4cbfa9c6fa6141d59e05bcdfc60cb6e1f1d3baa18d8c62fef5f"},
-    {file = "SQLAlchemy-1.4.29-cp38-cp38-win_amd64.whl", hash = "sha256:878daecb6405e786b07f97e1c77a9cfbbbec17432e8a90c487967e32cfdecb33"},
-    {file = "SQLAlchemy-1.4.29-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:e027bdf0a4cf6bd0a3ad3b998643ea374d7991bd117b90bf9982e41ceb742941"},
-    {file = "SQLAlchemy-1.4.29-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5de7adfb91d351f44062b8dedf29f49d4af7cb765be65816e79223a4e31062b"},
-    {file = "SQLAlchemy-1.4.29-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fbc6e63e481fa323036f305ada96a3362e1d60dd2bfa026cac10c3553e6880e9"},
-    {file = "SQLAlchemy-1.4.29-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dd0502cb091660ad0d89c5e95a29825f37cde2a5249957838e975871fbffaad"},
-    {file = "SQLAlchemy-1.4.29-cp39-cp39-win32.whl", hash = "sha256:37b46bfc4af3dc226acb6fa28ecd2e1fd223433dc5e15a2bad62bf0a0cbb4e8b"},
-    {file = "SQLAlchemy-1.4.29-cp39-cp39-win_amd64.whl", hash = "sha256:08cfd35eecaba79be930c9bfd2e1f0c67a7e1314355d83a378f9a512b1cf7587"},
-    {file = "SQLAlchemy-1.4.29.tar.gz", hash = "sha256:fa2bad14e1474ba649cfc969c1d2ec915dd3e79677f346bbfe08e93ef9020b39"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c3abc34fed19fdeaead0ced8cf56dd121f08198008c033596aa6aae7cc58f59f"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8d0949b11681380b4a50ac3cd075e4816afe9fa4a8c8ae006c1ca26f0fa40ad8"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-win32.whl", hash = "sha256:f3b7ec97e68b68cb1f9ddb82eda17b418f19a034fa8380a0ac04e8fe01532875"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27m-win_amd64.whl", hash = "sha256:81f2dd355b57770fdf292b54f3e0a9823ec27a543f947fa2eb4ec0df44f35f0d"},
+    {file = "SQLAlchemy-1.4.31-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4ad31cec8b49fd718470328ad9711f4dc703507d434fd45461096da0a7135ee0"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:05fa14f279d43df68964ad066f653193187909950aa0163320b728edfc400167"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dccff41478050e823271642837b904d5f9bda3f5cf7d371ce163f00a694118d6"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57205844f246bab9b666a32f59b046add8995c665d9ecb2b7b837b087df90639"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea8210090a816d48a4291a47462bac750e3bc5c2442e6d64f7b8137a7c3f9ac5"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-win32.whl", hash = "sha256:2e216c13ecc7fcdcbb86bb3225425b3ed338e43a8810c7089ddb472676124b9b"},
+    {file = "SQLAlchemy-1.4.31-cp310-cp310-win_amd64.whl", hash = "sha256:e3a86b59b6227ef72ffc10d4b23f0fe994bef64d4667eab4fb8cd43de4223bec"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:2fd4d3ca64c41dae31228b80556ab55b6489275fb204827f6560b65f95692cf3"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f22c040d196f841168b1456e77c30a18a3dc16b336ddbc5a24ce01ab4e95ae0"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0c7171aa5a57e522a04a31b84798b6c926234cb559c0939840c3235cf068813"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d046a9aeba9bc53e88a41e58beb72b6205abb9a20f6c136161adf9128e589db5"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-win32.whl", hash = "sha256:d86132922531f0dc5a4f424c7580a472a924dd737602638e704841c9cb24aea2"},
+    {file = "SQLAlchemy-1.4.31-cp36-cp36m-win_amd64.whl", hash = "sha256:ca68c52e3cae491ace2bf39b35fef4ce26c192fd70b4cd90f040d419f70893b5"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:cf2cd387409b12d0a8b801610d6336ee7d24043b6dd965950eaec09b73e7262f"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb4b15fb1f0aafa65cbdc62d3c2078bea1ceecbfccc9a1f23a2113c9ac1191fa"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c317ddd7c586af350a6aef22b891e84b16bff1a27886ed5b30f15c1ed59caeaa"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c7ed6c69debaf6198fadb1c16ae1253a29a7670bbf0646f92582eb465a0b999"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-win32.whl", hash = "sha256:6a01ec49ca54ce03bc14e10de55dfc64187a2194b3b0e5ac0fdbe9b24767e79e"},
+    {file = "SQLAlchemy-1.4.31-cp37-cp37m-win_amd64.whl", hash = "sha256:330eb45395874cc7787214fdd4489e2afb931bc49e0a7a8f9cd56d6e9c5b1639"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5e9c7b3567edbc2183607f7d9f3e7e89355b8f8984eec4d2cd1e1513c8f7b43f"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de85c26a5a1c72e695ab0454e92f60213b4459b8d7c502e0be7a6369690eeb1a"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:975f5c0793892c634c4920057da0de3a48bbbbd0a5c86f5fcf2f2fedf41b76da"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5c20c8415173b119762b6110af64448adccd4d11f273fb9f718a9865b88a99c"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-win32.whl", hash = "sha256:b35dca159c1c9fa8a5f9005e42133eed82705bf8e243da371a5e5826440e65ca"},
+    {file = "SQLAlchemy-1.4.31-cp38-cp38-win_amd64.whl", hash = "sha256:b7b20c88873675903d6438d8b33fba027997193e274b9367421e610d9da76c08"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:85e4c244e1de056d48dae466e9baf9437980c19fcde493e0db1a0a986e6d75b4"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e79e73d5ee24196d3057340e356e6254af4d10e1fc22d3207ea8342fc5ffb977"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:15a03261aa1e68f208e71ae3cd845b00063d242cbf8c87348a0c2c0fc6e1f2ac"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ddc5e5ccc0160e7ad190e5c61eb57560f38559e22586955f205e537cda26034"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-win32.whl", hash = "sha256:289465162b1fa1e7a982f8abe59d26a8331211cad4942e8031d2b7db1f75e649"},
+    {file = "SQLAlchemy-1.4.31-cp39-cp39-win_amd64.whl", hash = "sha256:9e4fb2895b83993831ba2401b6404de953fdbfa9d7d4fa6a4756294a83bbc94f"},
+    {file = "SQLAlchemy-1.4.31.tar.gz", hash = "sha256:582b59d1e5780a447aada22b461e50b404a9dc05768da1d87368ad8190468418"},
 ]
 stevedore = [
     {file = "stevedore-3.5.0-py3-none-any.whl", hash = "sha256:a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c"},
@@ -2145,7 +2232,7 @@ subprocess32 = [
     {file = "subprocess32-3.5.4.tar.gz", hash = "sha256:eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"},
 ]
 tensorboard = [
-    {file = "tensorboard-2.7.0-py3-none-any.whl", hash = "sha256:239f78a4a8dff200ce585a030c787773a8c1184d5c159252f5f85bac4e3c3b38"},
+    {file = "tensorboard-2.8.0-py3-none-any.whl", hash = "sha256:65a338e4424e9079f2604923bdbe301792adce2ace1be68da6b3ddf005170def"},
 ]
 tensorboard-data-server = [
     {file = "tensorboard_data_server-0.6.1-py3-none-any.whl", hash = "sha256:809fe9887682d35c1f7d1f54f0f40f98bb1f771b14265b453ca051e2ce58fca7"},
@@ -2205,6 +2292,14 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
+]
+types-requests = [
+    {file = "types-requests-2.27.7.tar.gz", hash = "sha256:f38bd488528cdcbce5b01dc953972f3cead0d060cfd9ee35b363066c25bab13c"},
+    {file = "types_requests-2.27.7-py3-none-any.whl", hash = "sha256:2e0e100dd489f83870d4f61949d3a7eae4821e7bfbf46c57e463c38f92d473d4"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.7.tar.gz", hash = "sha256:cfd1fbbe4ba9a605ed148294008aac8a7b8b7472651d1cc357d507ae5962e3d2"},
+    {file = "types_urllib3-1.26.7-py3-none-any.whl", hash = "sha256:3adcf2cb5981809091dbff456e6999fe55f201652d8c360f99997de5ac2f556e"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},

--- a/rogue_net/pyproject.toml
+++ b/rogue_net/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Clemens Winter <clemenswinter1@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
-ragged-buffer = "^0.3.3"
+ragged-buffer = "^0.3.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/rogue_net/rogue_net/actor.py
+++ b/rogue_net/rogue_net/actor.py
@@ -39,7 +39,6 @@ def tensor_dict_to_ragged(
 class Actor(nn.Module):
     def __init__(
         self,
-        obs_space: ObsSpace,
         embedding: nn.ModuleDict,
         action_space: Dict[str, ActionSpace],
         backbone: nn.Module,
@@ -50,7 +49,6 @@ class Actor(nn.Module):
     ):
         super(Actor, self).__init__()
 
-        self.obs_space = obs_space
         self.action_space = action_space
 
         self.embedding = embedding
@@ -217,8 +215,9 @@ class AutoActor(Actor):
     ):
         assert pooling_op in (None, "mean", "max", "meanmax")
         self.d_model = d_model
+        if feature_transforms is not None:
+            obs_space = feature_transforms.transform_obs_space(obs_space)
         super().__init__(
-            obs_space,
             embedding_creator.create_embeddings(obs_space, d_model),
             action_space,
             Transformer(

--- a/rogue_net/rogue_net/translate_positions.py
+++ b/rogue_net/rogue_net/translate_positions.py
@@ -1,12 +1,21 @@
-from dataclasses import dataclass
-from typing import Dict, List, Mapping
+from typing import Dict, List, Optional
 from entity_gym.environment import ObsSpace
+import ragged_buffer
 from ragged_buffer import RaggedBufferF32
+import numpy as np
+from copy import deepcopy
 
 
 class TranslatePositions:
     def __init__(
-        self, reference_entity: str, position_features: List[str], obs_space: ObsSpace
+        self,
+        reference_entity: str,
+        position_features: List[str],
+        obs_space: ObsSpace,
+        # x and y component of unit vector that give the direction of the reference entity. All other entities are rotated by this vector.
+        orientation_features: Optional[List[str]] = None,
+        # adds a feature that is the distance to the reference entity
+        add_dist_feature: bool = False,
     ):
         self.feature_indices = {
             entity_name: [
@@ -23,14 +32,52 @@ class TranslatePositions:
             obs_space.entities[reference_entity].features.index(feature_name)
             for feature_name in position_features
         ]
+        self.reference_orientation_indices = (
+            [
+                obs_space.entities[reference_entity].features.index(feature_name)
+                for feature_name in orientation_features
+            ]
+            if orientation_features is not None
+            else None
+        )
         self.reference_entity = reference_entity
+        self.add_dist_feature = add_dist_feature
 
     def apply(self, entities: Dict[str, RaggedBufferF32]) -> None:
         if self.reference_entity not in entities:
             return
         reference_entity = entities[self.reference_entity]
         origin = reference_entity[:, :, self.reference_indices]
+        orientation = (
+            reference_entity[:, :, self.reference_orientation_indices]
+            if self.reference_orientation_indices is not None
+            else None
+        )
         for entity_name, indices in self.feature_indices.items():
             if entity_name in entities:
-                feats = entities[entity_name][:, :, indices]
-                feats -= origin
+                if orientation is not None:
+                    ragged_buffer.translate_rotate(
+                        entities[entity_name][:, :, indices], origin, orientation
+                    )
+                else:
+                    feats = entities[entity_name][:, :, indices]
+                    feats -= origin
+
+                if self.add_dist_feature:
+                    # TODO: efficiency
+                    ea = entities[entity_name].as_array()
+                    np.linalg.norm(ea[:, indices], axis=1).reshape(-1, 1)
+                    entities[entity_name] = RaggedBufferF32.from_flattened(
+                        np.concatenate(
+                            [ea, np.linalg.norm(ea[:, indices], axis=1).reshape(-1, 1)],
+                            axis=1,
+                        ),
+                        entities[entity_name].size1(),
+                    )
+
+    def transform_obs_space(self, obs_space: ObsSpace) -> ObsSpace:
+        if self.add_dist_feature:
+            obs_space = deepcopy(obs_space)
+            for entity_name in self.feature_indices.keys():
+                obs_space.entities[entity_name].features.append("TranslatePositions.distance")
+        return obs_space

--- a/rogue_net/rogue_net/translate_positions.py
+++ b/rogue_net/rogue_net/translate_positions.py
@@ -79,5 +79,7 @@ class TranslatePositions:
         if self.add_dist_feature:
             obs_space = deepcopy(obs_space)
             for entity_name in self.feature_indices.keys():
-                obs_space.entities[entity_name].features.append("TranslatePositions.distance")
+                obs_space.entities[entity_name].features.append(
+                    "TranslatePositions.distance"
+                )
         return obs_space

--- a/xprun/traincc.ron
+++ b/xprun/traincc.ron
@@ -1,0 +1,96 @@
+XpV0(
+    project: "enn",
+    containers: {
+        "main": (
+            command: ["poetry", "run", "python", "-u", "enn_ppo/enn_ppo/train.py"],
+            build: [
+                From("nvcr.io/nvidia/pytorch:21.03-py3"),
+
+                // Install Poetry
+                Run("curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -"),
+                Env("PATH", "/root/.poetry/bin:${PATH}"),
+
+                // Install Vulkan drivers (required by Griddly)
+                Run("wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -"),
+                Run("wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list"),
+                Run("apt-get update"),
+                Run("DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata"),
+                Run("apt-get install vulkan-sdk -y"),
+
+                // Install Rust toolchain
+                Run("apt-get update"),
+                Run("apt-get install curl build-essential --yes"),
+                Run("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"),
+                Env("PATH", "/root/.cargo/bin:${PATH}"),
+
+                Repo(
+                    paths: [
+                        "pyproject.toml",
+                        "poetry.lock",
+                        "rogue_net/pyproject.toml",
+                        "rogue_net/poetry.lock",
+                        "rogue_net/rogue_net/__init__.py",
+                        "enn_ppo/pyproject.toml",
+                        "enn_ppo/poetry.lock",
+                        "enn_ppo/enn_ppo/__init__.py",
+                        "entity_gym/pyproject.toml",
+                        "entity_gym/poetry.lock",
+                        "entity_gym/entity_gym/__init__.py",
+                        "enn_zoo/pyproject.toml",
+                        "enn_zoo/poetry.lock",
+                        "enn_zoo/enn_zoo/__init__.py",
+                    ],
+                    target_dir: "/root/enn-incubator",
+                    cd: true,
+                ),
+
+                // Build xprun from source
+                Repo(url: "git@github.com:cswinter/xprun.git", rev: "c248812", target_dir: "/root"),
+                Run("poetry run pip install maturin==0.12.6"),
+                Run("poetry run maturin build --cargo-extra-args=--features=python --manifest-path=/root/xprun/Cargo.toml"),
+                Run("poetry run pip install /root/xprun/target/wheels/xprun-0.1.0-cp38-cp38-manylinux_2_31_x86_64.whl"),
+
+                Run("poetry install"),
+                Run("poetry run pip install torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html"),
+                Run("poetry run pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cu113.html"),
+
+                Repo(cd: true),
+            ],
+            gpu: 1,
+            gpu_mem: "5GB",
+            cpu_mem: "4GiB",
+            env_secrets: {
+                "WANDB_API_KEY": "wandb-api-key",
+            },
+            volumes: {
+                "/mnt/a/Dropbox/artifacts/xprun": "/mnt/xprun",
+            },
+        ),
+
+        "codecraftserver": (
+            command: ["server-0.1.0-SNAPSHOT/bin/server", "-Dplay.http.secret.key=ad31779d4ee49d5ad5162bf1429c32e2e9933f3b"],
+            cpu: 4,
+            cpu_mem: "12GiB",
+            tty: true,
+            env: {
+                "SBT_OPTS": "-Xmx10G",
+            },
+            build: [
+                From("hseeberger/scala-sbt:8u222_1.3.5_2.13.1"),
+
+                // build fixed versions of CodeCraftGame and CodeCraftServer as a straightforward way to download sbt 0.13.16 and populate dependency cache
+                Repo(url: "https://github.com/cswinter/CodeCraftGame.git", rev: "92304eb", cd: true, rm: true),
+                Run("sbt publishLocal"),
+                Repo(url: "https://github.com/cswinter/CodeCraftServer.git", rev: "df76892", cd: true, rm: true),
+                Run("sbt compile"),
+
+                // build CodeCraftGame and CodeCraftServer from source
+                Repo(url: "https://github.com/cswinter/CodeCraftGame.git", rev: "edc5a9f2", cd: true),
+                Run("sbt publishLocal"),
+                Repo(url: "https://github.com/cswinter/CodeCraftServer.git", rev: "302a379", cd: true),
+                Run("sbt dist"),
+                Run("unzip server/target/universal/server-0.1.0-SNAPSHOT.zip"),
+            ],
+        ),
+    }
+)


### PR DESCRIPTION
Implements entity-gym interface for [CodeCraft](https://github.com/cswinter/codecraftgame), based on Python interface in https://github.com/cswinter/DeepCodeCraft. Currently only supports the `ALLIED_WEALTH` task where a single drone has to collect as many minerals as possible within some window.

To match the performance of the original implementation, I also added a `orientation_features` option to the `TranslatePositions` transform which rotates all other entities to align them with the direction of the reference entity, as well as an `add_dist_feature` option that adds a feature which gives the distance to the reference entity. Performance is still somewhat below my previous baselines ([W&B](https://wandb.ai/entity-neural-network/enn-ppo/reports/CodeCraft-ALLIED_WEALTH-reproduction--VmlldzoxNDc1OTE3)), but close enough that this could plausible just be due to less well-tuned hyperparmeters.

DeepCodeCraft:

![image](https://user-images.githubusercontent.com/12845088/150716583-0a63a252-6469-44e6-bb0a-8cf17f142eed.png)

enn-ppo:

![image](https://user-images.githubusercontent.com/12845088/150716653-12e3a6d4-91ec-42f4-ae10-669643602a29.png)
