### PR TITLE
Fix bug in merging ObsBatches

### DIFF
--- a/entity_gym/entity_gym/environment/vec_env.py
+++ b/entity_gym/entity_gym/environment/vec_env.py
@@ -118,6 +118,7 @@ class ObsBatch:
         """
         Merges ObsBatch b into this batch
         """
+        envs = len(self.ids)
 
         # merge entities
         for k in b.entities.keys():
@@ -133,7 +134,8 @@ class ObsBatch:
         self.reward = np.concatenate((self.reward, b.reward))
         self.done = np.concatenate((self.done, b.done))
 
-        self.end_of_episode_info.update(b.end_of_episode_info)
+        for i, stats in b.end_of_episode_info.items():
+            self.end_of_episode_info[i + envs] = stats
 
 
 class VecEnv(ABC):

--- a/entity_gym/entity_gym/tests/test_environment.py
+++ b/entity_gym/entity_gym/tests/test_environment.py
@@ -1,4 +1,5 @@
 from entity_gym.examples.cherry_pick import CherryPick
+from entity_gym.examples.xor import Xor
 from entity_gym.environment.env_list import EnvList
 from entity_gym.environment.parallel_env_list import ParallelEnvList
 from entity_gym.environment import (
@@ -9,6 +10,7 @@ from entity_gym.environment import (
     CategoricalActionMaskBatch,
     SelectEntityActionMaskBatch,
     SelectEntityAction,
+    CategoricalAction,
     Observation,
     ObsSpace,
     ObsBatch,
@@ -56,8 +58,15 @@ def test_parallel_env_list() -> None:
         {"Pick Cherry": SelectEntityAction(actions=[("Player", "Cherry 1")])}
     ] * 100
     obs_act = envs.act(actions, obs_space)
-
     assert len(obs_act.ids) == 100
+
+    envs = ParallelEnvList(Xor, {}, 100, 10)
+    obs_reset = envs.reset(Xor.obs_space())
+    assert len(obs_reset.ids) == 100
+    actions_xor = [{"output": CategoricalAction(actions=[(0, 0)])}] * 100
+    obs_act = envs.act(actions_xor, Xor.obs_space())
+    assert len(obs_act.ids) == 100
+    assert len(obs_act.end_of_episode_info) == 100
 
 
 def test_batch_obs_entities() -> None:


### PR DESCRIPTION
The `end_of_episode_info` is keyed by the index of the environment within each batch, which causes EpisodeStats to have the wrong key and overwrite stats from other envs when merging batches. We need to add an offset to prevent collisions.