### PR TITLE
Behavioral cloning

### DIFF
--- a/enn_ppo/README.md
+++ b/enn_ppo/README.md
@@ -2,40 +2,18 @@
 
 PPO implementation compatible with Entity Gym.
 
+Example usage:
 
+```bash
+poetry run python enn_ppo/enn_ppo/train.py
+```
 
+To run behavioral cloning on recorded samples:
 
-
-## WORK IN PROGRESS Implementation details
-
-The `rewards`, `dones`, and `values` can be stored in fixed-size preallocated tensors
-as usual, since there is only one value per timestep and environment.
-Observations, actions, and logprobs don't have a fixed shape and therefore require
-special handling that differs during rollout and optimization.
-
-### Rollouts
-
-On each rollout step, environments return a `List[Observation]` and expect a `List[Dict[str, Action]]`.
-
-Each observation has two components:
-
-- `entities: Dict[str, np.ndarray]` maps each entity type to a (num_entity, num_feats) array of features.
-- `action_masks: Mapping[str, ActionMask]` maps each action type to a list of indices of entities that can perform that action.
-
-- `List[]
-
-Each observation has a `Dict[str, np.ndarray]` 
-- shuffling
-- batching
-
-### Optimization
-
-
-
-### Ragged batch tensors
-
-
-
-### Issues and possible improvements 
-
-
+```bash
+# Download data (261MB)
+# Larger 5GB file with 1M samples: https://www.dropbox.com/s/o7jf4r7m0xtm80p/enhanced250m-1m-v2.blob?dl=1
+wget 'https://www.dropbox.com/s/es84ml3wltxdmnh/enhanced250m-60k.blob?dl=1' -O enhanced250m-60k.blob
+# Run training
+poetry run python enn_ppo/enn_ppo/supervised.py --batch-size=1024 --lr=0.001 --filepath=enhanced250m-1m-60m.blob --track
+```

--- a/enn_ppo/enn_ppo/supervised.py
+++ b/enn_ppo/enn_ppo/supervised.py
@@ -78,8 +78,9 @@ def load_dataset(filepath: str, batch_size: int) -> Tuple[Trace, DataSet, DataSe
     trace = Trace.deserialize(open(filepath, "rb").read(), progress_bar=True)
     episodes = trace.episodes(progress_bar=True)
 
-    test = episodes[-2:]
-    train = episodes[:-2]
+    test_episodes = max(len(episodes) // 20, 1) * 2
+    test = episodes[-test_episodes:]
+    train = episodes[:-test_episodes]
     return (
         trace,
         DataSet.from_episodes(train, batch_size=batch_size),

--- a/enn_ppo/enn_ppo/supervised.py
+++ b/enn_ppo/enn_ppo/supervised.py
@@ -184,7 +184,7 @@ def train(
         for batch in range(trainds.nbatch):
             optimizer.zero_grad()
             if anneal_lr:
-                frac = 1.0 - (epoch * trainds.frames + batch * trainds.nbatch) / (
+                frac = 1.0 - (epoch * trainds.frames + batch * trainds.batch_size) / (
                     epochs * trainds.frames
                 )
                 lrnow = frac * lr

--- a/enn_ppo/enn_ppo/supervised.py
+++ b/enn_ppo/enn_ppo/supervised.py
@@ -226,7 +226,7 @@ def train(
                         device,
                     )
                     test_loss += loss.item()
-                test_loss /= (fast_eval_samples // testds.batch_size)
+                test_loss /= fast_eval_samples // testds.batch_size
                 print(f"Fast test loss {test_loss:.4f}")
                 if track:
                     wandb.log(

--- a/enn_ppo/enn_ppo/supervised.py
+++ b/enn_ppo/enn_ppo/supervised.py
@@ -137,9 +137,12 @@ def compute_loss(
         elif loss_fn == "mse":
             logprob = newlogprob[actname]
             target = torch.tensor(target_logprob.as_array(), device=device)
-            loss += F.mse_loss(logprob.masked_fill(mask=logprob==float('-inf'), value=0.0), target.masked_fill(mask=target==float('-inf'), value=0.0))
-            if torch.any(logprob == float('-inf')):
-                __import__('ipdb').set_trace()
+            loss += F.mse_loss(
+                logprob.masked_fill(mask=logprob == float("-inf"), value=0.0),
+                target.masked_fill(mask=target == float("-inf"), value=0.0),
+            )
+            if torch.any(logprob == float("-inf")):
+                __import__("ipdb").set_trace()
     return loss, sum(e.mean().item() for _, e in entropy.items())
 
 

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -496,7 +496,7 @@ def run_eval(
     # TODO: metrics are biased towards short episodes
     eval_envs: VecEnv
     if codecraft_eval:
-        eval_envs = CodeCraftVecEnv(num_envs, stagger=False, fair=True, **env_kwargs)
+        eval_envs = CodeCraftVecEnv(num_envs, stagger=False, symmetric=True, **env_kwargs)
     elif processes > 1:
         eval_envs = ParallelEnvList(
             env_cls,

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -85,6 +85,8 @@ def parse_args(override_args: Optional[List[str]] = None) -> argparse.Namespace:
     # Evals
     parser.add_argument('--eval-interval', type=int, default=None,
         help='number of global steps between evaluations')
+    parser.add_argument('--eval-on-step-0', type=lambda x:bool(strtobool(x)), default=True, nargs='?', const=True,
+        help='whether to run eval on step 0')
     parser.add_argument('--eval-steps', type=int, default=None,
         help='number of sequential steps to evaluate for')
     parser.add_argument('--eval-num-envs', type=int, default=None,
@@ -727,7 +729,10 @@ def train(args: argparse.Namespace) -> float:
     )
 
     if args.eval_interval is not None:
-        next_eval_step: Optional[int] = 0
+        if args.eval_on_step_0:
+            next_eval_step: Optional[int] = 0
+        else:
+            next_eval_step = args.eval_interval
     else:
         next_eval_step = None
 

--- a/enn_ppo/poetry.lock
+++ b/enn_ppo/poetry.lock
@@ -203,8 +203,7 @@ python-versions = ">=3.8.0,<3.10"
 develop = true
 
 [package.dependencies]
-griddly = "^1.2.29"
-gym = "0.21.0"
+griddly = "1.2.31"
 hyperstate = "^0.1.3"
 orjson = "^3.6.5"
 requests = "^2.27.1"
@@ -301,7 +300,7 @@ docs = ["sphinx"]
 
 [[package]]
 name = "griddly"
-version = "1.2.35"
+version = "1.2.31"
 description = "Griddly Python Libraries"
 category = "main"
 optional = false
@@ -329,27 +328,36 @@ protobuf = ["grpcio-tools (>=1.44.0)"]
 
 [[package]]
 name = "gym"
-version = "0.21.0"
+version = "0.22.0"
 description = "Gym: A universal API for reinforcement learning environments."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 cloudpickle = ">=1.2.0"
+gym_notices = ">=0.0.4"
+importlib_metadata = {version = ">=4.10.0", markers = "python_version < \"3.10\""}
 numpy = ">=1.18.0"
 
 [package.extras]
 accept-rom-license = ["autorom[accept-rom-license] (>=0.4.2,<0.5.0)"]
-all = ["mujoco_py (>=1.50,<2.0)", "lz4 (>=3.1.0)", "opencv-python (>=3)", "ale-py (>=0.7.1,<0.8.0)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "ale-py (>=0.7.1,<0.8.0)", "lz4 (>=3.1.0)", "opencv-python (>=3)", "pyglet (>=1.4.0)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "mujoco_py (>=1.50,<2.0)"]
-atari = ["ale-py (>=0.7.1,<0.8.0)"]
-box2d = ["box2d-py (==2.3.5)", "pyglet (>=1.4.0)"]
-classic_control = ["pyglet (>=1.4.0)"]
+all = ["pygame (==2.1.0)", "scipy (>=1.4.1)", "ale-py (>=0.7.4,<0.8.0)", "box2d-py (==2.3.5)", "pygame (==2.1.0)", "pygame (==2.1.0)", "pygame (==2.1.0)", "scipy (>=1.4.1)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "box2d-py (==2.3.5)", "pygame (==2.1.0)", "pygame (==2.1.0)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "mujoco_py (>=1.50,<2.0)"]
+atari = ["ale-py (>=0.7.4,<0.8.0)"]
+box2d = ["box2d-py (==2.3.5)", "pygame (==2.1.0)"]
+classic_control = ["pygame (==2.1.0)"]
 mujoco = ["mujoco_py (>=1.50,<2.0)"]
-nomujoco = ["lz4 (>=3.1.0)", "opencv-python (>=3)", "ale-py (>=0.7.1,<0.8.0)", "pyglet (>=1.4.0)", "scipy (>=1.4.1)", "box2d-py (==2.3.5)", "pyglet (>=1.4.0)"]
-other = ["lz4 (>=3.1.0)", "opencv-python (>=3)"]
-robotics = ["mujoco_py (>=1.50,<2.0)"]
-toy_text = ["scipy (>=1.4.1)"]
+nomujoco = ["pygame (==2.1.0)", "scipy (>=1.4.1)", "lz4 (>=3.1.0)", "opencv-python (>=3.0)", "box2d-py (==2.3.5)", "pygame (==2.1.0)", "pygame (==2.1.0)"]
+other = ["lz4 (>=3.1.0)", "opencv-python (>=3.0)"]
+toy_text = ["pygame (==2.1.0)", "scipy (>=1.4.1)"]
+
+[[package]]
+name = "gym-notices"
+version = "0.0.4"
+description = "Notices for gym"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "hyperstate"
@@ -1099,7 +1107,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "857dd17a1e6bf0928d8c65ea330517ed725d124d46d199e185b8db0dd61b74de"
+content-hash = "5a3ffed296f476e17e2ce1b2629076ac6b8e8c6c052cf02337d75212eaba18fc"
 
 [metadata.files]
 absl-py = [
@@ -1246,15 +1254,15 @@ greenlet = [
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
 griddly = [
-    {file = "griddly-1.2.35-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:9c694e3abb3b758b5b035e6baa3228a4e1f0d02a2a69bc09b2a2b2e302d4fbaa"},
-    {file = "griddly-1.2.35-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:c3466e6b0a0a73e37309eb079427a8254ba95c678cb21ba35f072c9df0600d91"},
-    {file = "griddly-1.2.35-cp37-cp37m-win_amd64.whl", hash = "sha256:b8b01bf04122770fbf2203ebfedea406e14cfaffcfc11379f25289e53dd9ae2a"},
-    {file = "griddly-1.2.35-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:a57d7dfbe1464dc3086a54c3be48c98bd1e2ef9e3bfc1a26726f8d1cc05d992b"},
-    {file = "griddly-1.2.35-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:9980947a69bca5badfc9ca93e6434b8fa93f4eea656a30c6314dd4dbc144111b"},
-    {file = "griddly-1.2.35-cp38-cp38-win_amd64.whl", hash = "sha256:01219e7d2692f674a4346818ae6c5e47dffcf97f695b014a9dcd18ed04b7b0e4"},
-    {file = "griddly-1.2.35-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:a8176b2221f62bdc38996c488f9733a30efeedd2c218c6321d71717e267aa509"},
-    {file = "griddly-1.2.35-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:3392a590f6363b4c298a7a363b59e346811ed63e06900313bbe15de50da2f8b1"},
-    {file = "griddly-1.2.35-cp39-cp39-win_amd64.whl", hash = "sha256:71d69ddfea223675ce6568f3b105350750a52d3938a13e0c7d309f35f9715742"},
+    {file = "griddly-1.2.31-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:7ab29267907d4527eca25c0116552d563a578f563b5343e4bca8aa4ed24c761c"},
+    {file = "griddly-1.2.31-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:f93442ed5178178a14844eb3f0f073b35a0a2e6dbda824842ec29c0a9a623ee7"},
+    {file = "griddly-1.2.31-cp37-cp37m-win_amd64.whl", hash = "sha256:64b312e996ebbceb727dd33df01737db163846b67dd178fbf2b5dab9e2507de7"},
+    {file = "griddly-1.2.31-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:36d20ff10e3ef7fab89cb4b2fb802b7fc7b911d1800554a1d7dd5e8d1e4161eb"},
+    {file = "griddly-1.2.31-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0431348ccf06be831ee34a5a36b004938f07cd3802fea0efa04ebeb50df17902"},
+    {file = "griddly-1.2.31-cp38-cp38-win_amd64.whl", hash = "sha256:064ce9c91a6db8d5bbcfb804b1f65990ef5a0b730cc9f16af47163e14be439b8"},
+    {file = "griddly-1.2.31-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:442363b1f07780b5368d97d9e015f422509e802c782fd30074728cbf5283192d"},
+    {file = "griddly-1.2.31-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c05e1dcd6d30b0d784554b9d9ccea98b473a3d23d9e3fcfd5771f85ac67e822e"},
+    {file = "griddly-1.2.31-cp39-cp39-win_amd64.whl", hash = "sha256:07c74fa7acae2c4465f01d62ab8efb5d1fdc5c0abcb610c2cb2b7cb57a3174c7"},
 ]
 grpcio = [
     {file = "grpcio-1.44.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:11f811c0fffd84fca747fbc742464575e5eb130fd4fb4d6012ccc34febd001db"},
@@ -1303,7 +1311,11 @@ grpcio = [
     {file = "grpcio-1.44.0.tar.gz", hash = "sha256:4bae1c99896045d3062ab95478411c8d5a52cb84b91a1517312629fa6cfeb50e"},
 ]
 gym = [
-    {file = "gym-0.21.0.tar.gz", hash = "sha256:0fd1ce165c754b4017e37a617b097c032b8c3feb8a0394ccc8777c7c50dddff3"},
+    {file = "gym-0.22.0.tar.gz", hash = "sha256:339144c89951758187c378111919bc0e2f1695f9e9d9699e3f19279a6398148d"},
+]
+gym-notices = [
+    {file = "gym-notices-0.0.4.tar.gz", hash = "sha256:c490570fa91acafe25768f9877cc0dfe0700d68fb25dc9dfa84512e4bcf01805"},
+    {file = "gym_notices-0.0.4-py3-none-any.whl", hash = "sha256:933712d50f415e441b72ab6fe42c5007a1e8208c5944dbb0d9b75be3fcb7b58b"},
 ]
 hyperstate = [
     {file = "hyperstate-0.1.3-py3-none-any.whl", hash = "sha256:20e97d985483592c711d4b8d858b63767bf337b71acc9e54f0a5935c68fae06c"},
@@ -1587,6 +1599,11 @@ psutil = [
     {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
     {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
     {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
+    {file = "psutil-5.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56"},
+    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203"},
+    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d"},
+    {file = "psutil-5.9.0-cp36-cp36m-win32.whl", hash = "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64"},
+    {file = "psutil-5.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94"},
     {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
@@ -1703,12 +1720,17 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 ragged-buffer = [
+    {file = "ragged_buffer-0.3.6-cp310-none-win_amd64.whl", hash = "sha256:05adb2b866ea20d86304cd76370df3d072d0b26ff44228fcf7a1c7a3ad7d1dbf"},
+    {file = "ragged_buffer-0.3.6-cp36-none-win_amd64.whl", hash = "sha256:efca6a2936cece6c3691fd4b95bf4f6edd9c8ebadd4b38a2c644804f9ca7c106"},
     {file = "ragged_buffer-0.3.6-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:e0d42c5948350ebb5333cbe89f7f0a840a90bc25364ea5e9594f71f85be56c91"},
     {file = "ragged_buffer-0.3.6-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:c46e4b0792761c2c3363a24f9df9cdb85289ce8a4e44b4720ce365c353669fa3"},
+    {file = "ragged_buffer-0.3.6-cp37-none-win_amd64.whl", hash = "sha256:1e55becae8d3723ba091dd0afd4c2babfd8decbd1444bb455590890a86ba02f7"},
     {file = "ragged_buffer-0.3.6-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:9b4eb6a8977aedf3b7ec67f120d5aadd6634aef191b172e5ed3ed4829b0e04c5"},
     {file = "ragged_buffer-0.3.6-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:97d08ee0f4a7fdb419bc7da9e62c00067db5ca4eb42c8f8847cee62c0ce15f42"},
+    {file = "ragged_buffer-0.3.6-cp38-none-win_amd64.whl", hash = "sha256:c0527e6eb7477a2e5a2ae606cb1ce6be0d471f85d5ca2ed443adff0c55e26f3b"},
     {file = "ragged_buffer-0.3.6-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:fe9faaad3839c5d7f99514f1c5c3005419c420216d60a74415c39e136d55c862"},
     {file = "ragged_buffer-0.3.6-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:aef4893781dd9d4d11fa18a78e3dc84bccad83080d3652b2552d4405997f8680"},
+    {file = "ragged_buffer-0.3.6-cp39-none-win_amd64.whl", hash = "sha256:e1281ae04ca5770c57674c01c833bd184678afad1261a9549ff92ae8f1fddf80"},
     {file = "ragged_buffer-0.3.6.tar.gz", hash = "sha256:927540fccbc7d17c68650d71860cc2f8e3a175972b1ddfb92b47d99d1b8b4e51"},
 ]
 requests = [

--- a/enn_ppo/pyproject.toml
+++ b/enn_ppo/pyproject.toml
@@ -18,8 +18,7 @@ moviepy = "^1.0.3"
 enn_zoo = {path = "../enn_zoo", develop = true}
 entity_gym = {path = "../entity_gym", develop = true}
 rogue_net = {path = "../rogue_net", develop = true}
-
-[tool.poetry.dev-dependencies]
+click = "^8.0.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/enn_zoo/enn_zoo/codecraft/codecraftnet/adapter.py
+++ b/enn_zoo/enn_zoo/codecraft/codecraftnet/adapter.py
@@ -161,7 +161,7 @@ class CCNetAdapter(nn.Module):
             }
             if "act" in action_masks
             else {},
-            {"act": logprobs},
+            {"act": logprobs.reshape(-1, 1)},
             {"act": entropy.unsqueeze(-1)},
             {"act": allies.size1()},
             {"value": values.unsqueeze(-1)},

--- a/enn_zoo/enn_zoo/codecraft/codecraftnet/adapter.py
+++ b/enn_zoo/enn_zoo/codecraft/codecraftnet/adapter.py
@@ -143,7 +143,7 @@ class CCNetAdapter(nn.Module):
         if prev_actions is None and VERIFY:
             assert np.array_equal(LAST_OBS["obs"], obs.cpu().numpy())
             assert np.array_equal(LAST_OBS["masks"], masks.cpu().float().numpy())
-        actions, logprobs, entropy, values, probs = self.network.evaluate(
+        actions, logprobs, entropy, values, logits = self.network.evaluate(
             obs,
             masks,
             privileged_obs=None,
@@ -165,7 +165,7 @@ class CCNetAdapter(nn.Module):
             {"act": entropy.unsqueeze(-1)},
             {"act": allies.size1()},
             {"value": values.unsqueeze(-1)},
-            {},
+            {"act": logits},
         )
 
     def get_value(

--- a/enn_zoo/enn_zoo/codecraft/codecraftnet/codecraftnet.py
+++ b/enn_zoo/enn_zoo/codecraft/codecraftnet/codecraftnet.py
@@ -417,7 +417,6 @@ class TransformerPolicy8HS(nn.Module, hyperstate.lazy.Serializable):
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Any]:
         action_masks = action_masks[:, : self.agents, :]
         logits, v = self.forward(observation, privileged_obs, action_masks)
-        # logits = logits.view(-1, self.agents, self.naction)
         if action_masks.size(2) != self.naction:
             nbatch, nagent, naction = action_masks.size()
             zeros = torch.zeros(nbatch, nagent, self.naction - naction).to(
@@ -435,7 +434,7 @@ class TransformerPolicy8HS(nn.Module, hyperstate.lazy.Serializable):
             action_dist.log_prob(actions),
             entropy,
             v,
-            None,
+            action_dist.logits,
         )
 
     def forward(

--- a/entity_gym/entity_gym/serialization/msgpack_ragged.py
+++ b/entity_gym/entity_gym/serialization/msgpack_ragged.py
@@ -14,6 +14,8 @@ WHITELIST = {
     "VecSelectEntityActionMask": VecSelectEntityActionMask,
     "SelectEntityAction": SelectEntityAction,
     "CategoricalAction": CategoricalAction,
+    "SelectEntityActionSpace": SelectEntityActionSpace,
+    "CategoricalActionSpace": CategoricalActionSpace,
     "Entity": Entity,
     "EpisodeStats": EpisodeStats,
 }

--- a/entity_gym/entity_gym/serialization/msgpack_ragged.py
+++ b/entity_gym/entity_gym/serialization/msgpack_ragged.py
@@ -54,6 +54,10 @@ def ragged_buffer_decode(obj: Any) -> Any:
                 return RaggedBufferF32.from_flattened(flattened, lengths)
             elif dtype == int:
                 return RaggedBufferI64.from_flattened(flattened, lengths)
+            elif dtype == bool:
+                return RaggedBufferBool.from_flattened(flattened, lengths)
+            else:
+                raise ValueError(f"Unsupported RaggedBuffer dtype: {dtype}")
         elif "__classname__" in obj:
             classname = obj["__classname__"]
             if classname in WHITELIST:

--- a/entity_gym/entity_gym/serialization/sample_loader.py
+++ b/entity_gym/entity_gym/serialization/sample_loader.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
+from entity_gym.environment.environment import ActionSpace
+from entity_gym.environment.vec_env import VecActionMask, VecCategoricalActionMask
 
-from ragged_buffer import RaggedBufferF32
+import msgpack_numpy
+from ragged_buffer import RaggedBufferF32, RaggedBufferI64
 import tqdm
 import numpy as np
 
@@ -10,6 +13,7 @@ from entity_gym.environment import (
     ObsSpace,
 )
 from entity_gym.serialization.sample_recorder import Sample
+from entity_gym.serialization.msgpack_ragged import ragged_buffer_decode
 
 
 @dataclass
@@ -17,7 +21,8 @@ class Episode:
     number: int
     steps: int
     entities: Dict[str, RaggedBufferF32]
-    actions: Dict[str, List[Action]]
+    actions: Dict[str, RaggedBufferI64]
+    masks: Dict[str, VecActionMask]
     logprobs: Dict[str, RaggedBufferF32]
     logits: Dict[str, RaggedBufferF32]
     total_reward: float
@@ -26,7 +31,7 @@ class Episode:
 
 @dataclass
 class Trace:
-    action_space: Dict[str, int]
+    action_space: Dict[str, ActionSpace]
     obs_space: ObsSpace
     samples: List[Sample]
 
@@ -37,6 +42,19 @@ class Trace:
             pbar = tqdm.tqdm(total=len(data))
 
         offset = 0
+        # Read version
+        version = int(np.frombuffer(data[:8], dtype=np.uint64)[0])
+        assert version == 0
+        header_len = int(np.frombuffer(data[8:16], dtype=np.uint64)[0])
+        header = msgpack_numpy.loads(
+            data[16 : 16 + header_len],
+            object_hook=ragged_buffer_decode,
+            strict_map_key=False,
+        )
+        action_space = header["act_space"]
+        obs_space = header["obs_space"]
+
+        offset = 16 + header_len
         while offset < len(data):
             size = int(np.frombuffer(data[offset : offset + 8], dtype=np.uint64)[0])
             offset += 8
@@ -44,7 +62,7 @@ class Trace:
             offset += size
             if progress_bar:
                 pbar.update(size + 8)
-        return Trace(None, None, samples)  # type: ignore
+        return Trace(action_space, obs_space, samples)
 
     def episodes(
         self, include_incomplete: bool = False, progress_bar: bool = False
@@ -58,7 +76,16 @@ class Trace:
         for sample in samples:
             for i, e in enumerate(sample.episode):
                 if e not in episodes:
-                    episodes[e] = Episode(e, 0, {}, {}, {}, {}, 0.0)
+                    episodes[e] = Episode(
+                        e,
+                        0,
+                        {},
+                        {},
+                        {},
+                        {},
+                        {},
+                        0.0,
+                    )
 
                 episodes[e].steps += 1
                 episodes[e].total_reward += sample.obs.reward[i]
@@ -72,9 +99,14 @@ class Trace:
                         episodes[e].entities[name].extend(feats[i])
                 for name, acts in sample.actions.items():
                     if name not in episodes[e].actions:
-                        episodes[e].actions[name] = [acts[i]]
+                        episodes[e].actions[name] = acts[i]
                     else:
-                        episodes[e].actions[name].append(acts[i])
+                        episodes[e].actions[name].extend(acts[i])
+                for name, mask in sample.obs.action_masks.items():
+                    if name not in episodes[e].masks:
+                        episodes[e].masks[name] = mask[i]
+                    else:
+                        episodes[e].masks[name].extend(mask[i])
                 for name, logprobs in sample.probs.items():
                     if name not in episodes[e].logprobs:
                         episodes[e].logprobs[name] = logprobs[i]

--- a/entity_gym/entity_gym/serialization/sample_loader.py
+++ b/entity_gym/entity_gym/serialization/sample_loader.py
@@ -70,21 +70,22 @@ class Trace:
                         episodes[e].entities[name] = feats[i]
                     else:
                         episodes[e].entities[name].extend(feats[i])
-                for name, acts in sample.actions[i].items():
+                for name, acts in sample.actions.items():
                     if name not in episodes[e].actions:
-                        episodes[e].actions[name] = [acts]
+                        episodes[e].actions[name] = [acts[i]]
                     else:
-                        episodes[e].actions[name].append(acts)
+                        episodes[e].actions[name].append(acts[i])
                 for name, logprobs in sample.probs.items():
                     if name not in episodes[e].logprobs:
                         episodes[e].logprobs[name] = logprobs[i]
                     else:
                         episodes[e].logprobs[name].extend(logprobs[i])
-                for name, logits in sample.logits.items():
-                    if name not in episodes[e].logits:
-                        episodes[e].logits[name] = logits[i]
-                    else:
-                        episodes[e].logits[name].extend(logits[i])
+                if sample.logits is not None:
+                    for name, logits in sample.logits.items():
+                        if name not in episodes[e].logits:
+                            episodes[e].logits[name] = logits[i]
+                        else:
+                            episodes[e].logits[name].extend(logits[i])
             prev_episodes = sample.episode
         return sorted(
             [e for e in episodes.values() if e.complete or include_incomplete],

--- a/entity_gym/entity_gym/serialization/sample_recorder.py
+++ b/entity_gym/entity_gym/serialization/sample_recorder.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional, Sequence, Type, Any
+from entity_gym.environment.vec_env import VecActionMask
 
 from ragged_buffer import RaggedBufferF32, RaggedBufferI64
 import numpy as np
@@ -60,7 +61,19 @@ class SampleRecorder:
     ) -> None:
         self.path = path
         self.file = open(path, "wb")
-        # TODO: write header and obs space and act space
+
+        # Version 0
+        self.file.write(np.uint64(0).tobytes())
+
+        bytes = msgpack_numpy.dumps(
+            {
+                "act_space": act_space,
+                "obs_space": obs_space,
+            },
+            default=ragged_buffer_encode,
+        )
+        self.file.write(np.uint64(len(bytes)).tobytes())
+        self.file.write(bytes)
 
     def record(
         self,

--- a/entity_gym/entity_gym/tests/test_sample_recorder.py
+++ b/entity_gym/entity_gym/tests/test_sample_recorder.py
@@ -1,7 +1,7 @@
 import tempfile
 
 import numpy as np
-from ragged_buffer import RaggedBufferF32, RaggedBufferI64
+from ragged_buffer import RaggedBufferF32, RaggedBufferI64, RaggedBufferBool
 
 from entity_gym.environment import VecCategoricalActionMask, VecObs
 from entity_gym.serialization import Sample, SampleRecorder, Trace
@@ -41,7 +41,8 @@ def test_serde_sample() -> None:
             },
             action_masks={
                 "move": VecCategoricalActionMask(
-                    actors=RaggedBufferI64.from_array(np.array([[[0]]])), mask=None
+                    actors=RaggedBufferI64.from_array(np.array([[[0]]])),
+                    mask=RaggedBufferBool.from_array(np.array([[[True, False, True]]])),
                 ),
                 "shoot": VecCategoricalActionMask(
                     actors=RaggedBufferI64.from_array(np.array([[[0]]])), mask=None
@@ -90,6 +91,10 @@ def test_serde_sample() -> None:
             assert len(trace.samples) == 2
             assert trace.samples[0].obs.reward[0] == 0.3124125987123489
             assert trace.samples[1].obs.reward[0] == 1.0
+            assert (
+                trace.samples[0].obs.action_masks["move"]
+                == sample.obs.action_masks["move"]
+            )
             np.testing.assert_equal(
                 trace.samples[0].obs.features["hero"][0].as_array(),
                 np.array([[1.0, 2.0, 0.3, 100.0, 10.0]], dtype=np.float32),

--- a/poetry.lock
+++ b/poetry.lock
@@ -264,6 +264,7 @@ python-versions = ">=3.8,<3.10"
 develop = true
 
 [package.dependencies]
+click = "^8.0.4"
 enn_zoo = {path = "../enn_zoo", develop = true}
 entity_gym = {path = "../entity_gym", develop = true}
 moviepy = "^1.0.3"
@@ -2084,6 +2085,11 @@ psutil = [
     {file = "psutil-5.9.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2"},
     {file = "psutil-5.9.0-cp310-cp310-win32.whl", hash = "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d"},
     {file = "psutil-5.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b"},
+    {file = "psutil-5.9.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56"},
+    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203"},
+    {file = "psutil-5.9.0-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d"},
+    {file = "psutil-5.9.0-cp36-cp36m-win32.whl", hash = "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64"},
+    {file = "psutil-5.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94"},
     {file = "psutil-5.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce"},
     {file = "psutil-5.9.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5"},
@@ -2220,12 +2226,17 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 ragged-buffer = [
+    {file = "ragged_buffer-0.3.6-cp310-none-win_amd64.whl", hash = "sha256:05adb2b866ea20d86304cd76370df3d072d0b26ff44228fcf7a1c7a3ad7d1dbf"},
+    {file = "ragged_buffer-0.3.6-cp36-none-win_amd64.whl", hash = "sha256:efca6a2936cece6c3691fd4b95bf4f6edd9c8ebadd4b38a2c644804f9ca7c106"},
     {file = "ragged_buffer-0.3.6-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:e0d42c5948350ebb5333cbe89f7f0a840a90bc25364ea5e9594f71f85be56c91"},
     {file = "ragged_buffer-0.3.6-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:c46e4b0792761c2c3363a24f9df9cdb85289ce8a4e44b4720ce365c353669fa3"},
+    {file = "ragged_buffer-0.3.6-cp37-none-win_amd64.whl", hash = "sha256:1e55becae8d3723ba091dd0afd4c2babfd8decbd1444bb455590890a86ba02f7"},
     {file = "ragged_buffer-0.3.6-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:9b4eb6a8977aedf3b7ec67f120d5aadd6634aef191b172e5ed3ed4829b0e04c5"},
     {file = "ragged_buffer-0.3.6-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:97d08ee0f4a7fdb419bc7da9e62c00067db5ca4eb42c8f8847cee62c0ce15f42"},
+    {file = "ragged_buffer-0.3.6-cp38-none-win_amd64.whl", hash = "sha256:c0527e6eb7477a2e5a2ae606cb1ce6be0d471f85d5ca2ed443adff0c55e26f3b"},
     {file = "ragged_buffer-0.3.6-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:fe9faaad3839c5d7f99514f1c5c3005419c420216d60a74415c39e136d55c862"},
     {file = "ragged_buffer-0.3.6-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:aef4893781dd9d4d11fa18a78e3dc84bccad83080d3652b2552d4405997f8680"},
+    {file = "ragged_buffer-0.3.6-cp39-none-win_amd64.whl", hash = "sha256:e1281ae04ca5770c57674c01c833bd184678afad1261a9549ff92ae8f1fddf80"},
     {file = "ragged_buffer-0.3.6.tar.gz", hash = "sha256:927540fccbc7d17c68650d71860cc2f8e3a175972b1ddfb92b47d99d1b8b4e51"},
 ]
 requests = [

--- a/rogue_net/rogue_net/actor.py
+++ b/rogue_net/rogue_net/actor.py
@@ -31,9 +31,15 @@ ScalarType = TypeVar("ScalarType", bound=np.generic, covariant=True)
 def tensor_dict_to_ragged(
     rb_cls: Type[RaggedBuffer[ScalarType]],
     d: Dict[str, torch.Tensor],
-    lengths: Dict[str, npt.NDArray[np.int64]],
+    lengths: Dict[str, np.ndarray],
 ) -> Dict[str, RaggedBuffer[ScalarType]]:
-    return {k: rb_cls.from_flattened(v.cpu().numpy(), lengths[k]) for k, v in d.items()}
+    result = {}
+    for k, v in d.items():
+        flattened = v.cpu().numpy()
+        if flattened.ndim == 1:
+            flattened = flattened.reshape(-1, 1)
+        result[k] = rb_cls.from_flattened(flattened, lengths[k])
+    return result
 
 
 class Actor(nn.Module):

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -128,7 +128,9 @@ class PaddedSelectEntityActionHead(nn.Module):
                 torch.zeros((0, 1), dtype=torch.float32, device=device),
             )
 
-        actors = torch.tensor((mask.actors + index_offsets).as_array(), device=device)
+        actors = torch.tensor(
+            (mask.actors + index_offsets).as_array(), device=device
+        ).squeeze(-1)
         actor_embeds = x.data[actors]
         queries = self.query_proj(actor_embeds).squeeze(1)
         max_actors = actor_lengths.max()
@@ -149,7 +151,9 @@ class PaddedSelectEntityActionHead(nn.Module):
         query_mask = query_mask.view(len(actor_lengths), max_actors)
 
         actee_lengths = mask.actees.size1()
-        actees = torch.tensor((mask.actees + index_offsets).as_array(), device=device)
+        actees = torch.tensor(
+            (mask.actees + index_offsets).as_array(), device=device
+        ).squeeze(-1)
         actee_embeds = x.data[actees]
         keys = self.key_proj(actee_embeds).squeeze(1)
         max_actees = actee_lengths.max()
@@ -180,7 +184,10 @@ class PaddedSelectEntityActionHead(nn.Module):
         if prev_actions is None:
             action = dist.sample()
         else:
-            action = torch.tensor(prev_actions.as_array(), device=device).flatten()
+            action = (
+                torch.tensor(prev_actions.as_array(), device=device)
+                .flatten()
+            )
             padded_actions = torch.ones(
                 (logits.size(0) * logits.size(1)), dtype=torch.long, device=device
             )
@@ -189,10 +196,10 @@ class PaddedSelectEntityActionHead(nn.Module):
         logprob = dist.log_prob(action)
         entropy = dist.entropy()
         return (
-            action.flatten()[qindices].view(-1, 1),
+            action.flatten()[qindices],
             actor_lengths,
-            logprob.flatten()[qindices].view(-1, 1),
-            entropy.flatten()[qindices].view(-1, 1),
+            logprob.flatten()[qindices],
+            entropy.flatten()[qindices],
             logits,
         )
 

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -60,10 +60,10 @@ class CategoricalActionHead(nn.Module):
         lengths = mask.actors.size1()
         if len(mask.actors) == 0:
             return (
-                torch.zeros((0, 1), dtype=torch.int64, device=device),
+                torch.zeros((0), dtype=torch.int64, device=device),
                 lengths,
-                torch.zeros((0, 1), dtype=torch.float32, device=device),
-                torch.zeros((0, 1), dtype=torch.float32, device=device),
+                torch.zeros((0), dtype=torch.float32, device=device),
+                torch.zeros((0), dtype=torch.float32, device=device),
                 torch.zeros((0, self.n_choice), dtype=torch.float32, device=device),
             )
 
@@ -121,11 +121,11 @@ class PaddedSelectEntityActionHead(nn.Module):
         actor_lengths = mask.actors.size1()
         if len(mask.actors) == 0:
             return (
-                torch.zeros((0, 1), dtype=torch.int64, device=device),
+                torch.zeros((0), dtype=torch.int64, device=device),
                 actor_lengths,
-                torch.zeros((0, 1), dtype=torch.float32, device=device),
-                torch.zeros((0, 1), dtype=torch.float32, device=device),
-                torch.zeros((0, 1), dtype=torch.float32, device=device),
+                torch.zeros((0), dtype=torch.float32, device=device),
+                torch.zeros((0), dtype=torch.float32, device=device),
+                torch.zeros((0), dtype=torch.float32, device=device),
             )
 
         actors = torch.tensor(
@@ -184,10 +184,7 @@ class PaddedSelectEntityActionHead(nn.Module):
         if prev_actions is None:
             action = dist.sample()
         else:
-            action = (
-                torch.tensor(prev_actions.as_array(), device=device)
-                .flatten()
-            )
+            action = torch.tensor(prev_actions.as_array(), device=device).flatten()
             padded_actions = torch.ones(
                 (logits.size(0) * logits.size(1)), dtype=torch.long, device=device
             )

--- a/rogue_net/rogue_net/head_creator.py
+++ b/rogue_net/rogue_net/head_creator.py
@@ -67,8 +67,10 @@ class CategoricalActionHead(nn.Module):
                 torch.zeros((0, self.n_choice), dtype=torch.float32, device=device),
             )
 
-        actors = torch.tensor((mask.actors + index_offsets).as_array()).to(
-            x.data.device
+        actors = (
+            torch.tensor((mask.actors + index_offsets).as_array())
+            .to(x.data.device)
+            .squeeze(-1)
         )
         actor_embeds = x.data[actors]
         logits = self.proj(actor_embeds)
@@ -84,10 +86,10 @@ class CategoricalActionHead(nn.Module):
         if prev_actions is None:
             action = dist.sample()
         else:
-            action = torch.tensor(prev_actions.as_array()).to(x.data.device)
+            action = torch.tensor(prev_actions.as_array().squeeze(-1)).to(x.data.device)
         logprob = dist.log_prob(action)
         entropy = dist.entropy()
-        return action, lengths, logprob, entropy, logits
+        return action, lengths, logprob, entropy, dist.logits
 
 
 class PaddedSelectEntityActionHead(nn.Module):

--- a/rogue_net/rogue_net/tests/test_action_head.py
+++ b/rogue_net/rogue_net/tests/test_action_head.py
@@ -29,8 +29,8 @@ def test_empty_actors() -> None:
         ),
         prev_actions=None,
     )
-    assert action.shape == (0, 1)
+    assert action.shape == (0,)
     assert np.array_equal(lengths, np.array([0, 0, 0, 0]))
-    assert logprob.shape == (0, 1)
-    assert entropy.shape == (0, 1)
+    assert logprob.shape == (0,)
+    assert entropy.shape == (0,)
     assert logits.shape == (0, 2)

--- a/xprun/train.ron
+++ b/xprun/train.ron
@@ -58,7 +58,7 @@ XpV0(
             ],
             gpu: 1,
             gpu_mem: "5GB",
-            cpu_mem: "10GiB",
+            cpu_mem: "20GiB",
             env_secrets: {
                 "WANDB_API_KEY": "wandb-api-key",
             },

--- a/xprun/train.ron
+++ b/xprun/train.ron
@@ -58,7 +58,7 @@ XpV0(
             ],
             gpu: 1,
             gpu_mem: "5GB",
-            cpu_mem: "20GiB",
+            cpu_mem: "10GiB",
             env_secrets: {
                 "WANDB_API_KEY": "wandb-api-key",
             },

--- a/xprun/trainbc.ron
+++ b/xprun/trainbc.ron
@@ -1,0 +1,70 @@
+XpV0(
+    project: "enn",
+    containers: {
+        "main": (
+            command: ["poetry", "run", "python", "-u", "enn_ppo/enn_ppo/supervised.py"],
+            build: [
+                From("nvcr.io/nvidia/pytorch:21.03-py3"),
+
+                // Install Poetry
+                Run("curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -"),
+                Env("PATH", "/root/.poetry/bin:${PATH}"),
+
+                // Install Vulkan drivers (required by Griddly)
+                Run("wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add -"),
+                Run("wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list"),
+                Run("apt-get update"),
+                Run("DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata"),
+                Run("apt-get install vulkan-sdk -y"),
+
+                // Install Rust toolchain
+                Run("apt-get update"),
+                Run("apt-get install curl build-essential --yes"),
+                Run("curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"),
+                Env("PATH", "/root/.cargo/bin:${PATH}"),
+
+                Repo(
+                    paths: [
+                        "pyproject.toml",
+                        "poetry.lock",
+                        "rogue_net/pyproject.toml",
+                        "rogue_net/poetry.lock",
+                        "rogue_net/rogue_net/__init__.py",
+                        "enn_ppo/pyproject.toml",
+                        "enn_ppo/poetry.lock",
+                        "enn_ppo/enn_ppo/__init__.py",
+                        "entity_gym/pyproject.toml",
+                        "entity_gym/poetry.lock",
+                        "entity_gym/entity_gym/__init__.py",
+                        "enn_zoo/pyproject.toml",
+                        "enn_zoo/poetry.lock",
+                        "enn_zoo/enn_zoo/__init__.py",
+                    ],
+                    target_dir: "/root/enn-incubator",
+                    cd: true,
+                ),
+
+                // Build xprun from source
+                Repo(url: "git@github.com:cswinter/xprun.git", rev: "c248812", target_dir: "/root"),
+                Run("poetry run pip install maturin==0.12.6"),
+                Run("poetry run maturin build --cargo-extra-args=--features=python --manifest-path=/root/xprun/Cargo.toml"),
+                Run("poetry run pip install /root/xprun/target/wheels/xprun-0.1.0-cp38-cp38-manylinux_2_31_x86_64.whl"),
+
+                Run("poetry install"),
+                Run("poetry run pip install torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html"),
+                Run("poetry run pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cu113.html"),
+
+                Repo(cd: true),
+            ],
+            gpu: 1,
+            gpu_mem: "10GB",
+            cpu_mem: "10GiB",
+            env_secrets: {
+                "WANDB_API_KEY": "wandb-api-key",
+            },
+            volumes: {
+                "/mnt/a/Dropbox/artifacts/xprun": "/mnt/xprun",
+            },
+        )
+    }
+)

--- a/xprun/trainbc.ron
+++ b/xprun/trainbc.ron
@@ -58,7 +58,7 @@ XpV0(
             ],
             gpu: 1,
             gpu_mem: "10GB",
-            cpu_mem: "10GiB",
+            cpu_mem: "20GiB",
             env_secrets: {
                 "WANDB_API_KEY": "wandb-api-key",
             },


### PR DESCRIPTION
Adds a new `supervised.py` script to enn-ppo which trains a model from samples recorded by another policy. Also makes various improvements to the sample recorder:
- add `--eval-capture-samples`/`--eval-capture-logits` options to record samples/logits during eval to a file
- add `--eval-on-step-0` arg to enable/disable running eval on the first step
- add `--codecraft-only-opponent` to run an eval with only a loaded eval policy against itself (this is slightly hacky, I'm planning to remove all the CodeCraft-specific options later)
- include action and observation spaces when recording samples
- fix `RaggedBufferBool` getting deserialized to `None`
- misc fixes to the `SampleRecorder` and `Trace`

Resolves https://github.com/entity-neural-network/incubator/issues/5, https://github.com/entity-neural-network/incubator/issues/6, and https://github.com/entity-neural-network/incubator/issues/8.