### PR TITLE
Ensure that environments return valid Obserations

### DIFF
--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -19,6 +19,7 @@ from typing import (
 )
 import json
 from entity_gym.environment import *
+from entity_gym.environment.validator import validated_env
 from entity_gym.ragged_dict import RaggedActionDict, RaggedBatchDict
 
 import hyperstate
@@ -85,11 +86,12 @@ class EnvConfig:
     """Environment settings.
 
     Attributes:
-        kwargs: JSON dictionary with keyword arguments for the environment
-        num_envs: the number of game environments
-        num_steps: the number of steps to run in each environment per policy rollout
-        processes: The number of processes to use to collect env data. The envs are split as equally as possible across the processes
-        id: the id of the environment
+        kwargs: JSON dictionary with keyword arguments for the environment.
+        num_envs: The number of game environments.
+        num_steps: The number of steps to run in each environment per policy rollout.
+        processes: The number of processes to use to collect env data. The envs are split as equally as possible across the processes.
+        id: The id of the environment.
+        validate: Check that all observations returned by the environment are valid. Disable for better performance.
     """
 
     kwargs: str = "{}"
@@ -97,6 +99,7 @@ class EnvConfig:
     num_steps: int = 128
     processes: int = 1
     id: str = "MoveToOrigin"
+    validate: bool = True
 
 
 @dataclass
@@ -649,6 +652,8 @@ def train(cfg: ExperimentConfig) -> float:
 
     # env setup
     envs: VecEnv
+    if cfg.env.validate:
+        env_cls = validated_env(env_cls)
     if cfg.env.id == "CodeCraft":
         envs = CodeCraftVecEnv(cfg.env.num_envs, **env_kwargs)
     elif cfg.env.processes > 1:

--- a/entity_gym/entity_gym/environment/validator.py
+++ b/entity_gym/entity_gym/environment/validator.py
@@ -1,0 +1,133 @@
+from typing import Dict, Mapping, Type
+import numpy as np
+from entity_gym.environment.environment import (
+    Action,
+    ActionType,
+    CategoricalActionMask,
+    CategoricalActionSpace,
+    Environment,
+    Observation,
+    SelectEntityActionMask,
+    SelectEntityActionSpace,
+)
+
+
+def validated_env(env: Type[Environment]) -> Type[Environment]:
+    obs_space = env.obs_space()
+    action_space = env.action_space()
+
+    class ValidatedEnv(env):  # type: ignore
+        def act(self, action: Mapping[ActionType, Action]) -> Observation:
+            obs = super().act(action)
+            try:
+                self.validate(obs)
+            except AssertionError as e:
+                print(f"Invalid observation:\n{e}")
+                raise e
+            return obs  # type: ignore
+
+        def reset(self) -> Observation:
+            obs = super().reset()
+            try:
+                self.validate(obs)
+            except AssertionError as e:
+                print(f"Invalid observation:\n{e}")
+                raise e
+            return obs  # type: ignore
+
+        def validate(self, obs: Observation) -> None:
+            assert isinstance(
+                obs, Observation
+            ), f"Observation has invalid type: {type(obs)}"
+
+            # Validate features
+            for entity_type, entity_features in obs.features.items():
+                assert (
+                    entity_type in obs_space.entities
+                ), f"Features contain entity of type '{entity_type}' which is not in observation space: {list(obs_space.entities.keys())}"
+                if isinstance(entity_features, np.ndarray):
+                    assert (
+                        entity_features.dtype == np.float32
+                    ), f"Features of entity of type '{entity_type}' have invalid dtype: {entity_features.dtype}. Expected: {np.float32}"
+                    shape = entity_features.shape
+                    assert len(shape) == 2 and shape[1] == len(
+                        obs_space.entities[entity_type].features
+                    ), f"Features of entity of type '{entity_type}' have invalid shape: {shape}. Expected: (n, {len(obs_space.entities[entity_type].features)})"
+                else:
+                    for i, entity in enumerate(entity_features):
+                        assert len(entity) == len(
+                            obs_space.entities[entity_type].features
+                        ), f"Features of {i}-th entity of type '{entity_type}' have invalid length: {len(entity)}. Expected: {len(obs_space.entities[entity_type].features)}"
+
+                if entity_type in obs.ids:
+                    assert len(obs.ids[entity_type]) == len(
+                        entity_features
+                    ), f"Length of ids of entity of type '{entity_type}' does not match length of features: {len(obs.ids[entity_type])} != {len(entity_features)}"
+
+            # Validate ids
+            previous_ids = set()
+            for entity_type, entity_ids in obs.ids.items():
+                assert (
+                    entity_type in obs_space.entities
+                ), f"IDs contain entity of type '{entity_type}' which is not in observation space: {list(obs_space.entities.keys())}"
+                for id in entity_ids:
+                    assert (
+                        id not in previous_ids
+                    ), f"Observation has duplicate id '{id}'"
+                    previous_ids.add(id)
+
+            # Validate actions
+            ids = obs.id_to_index(obs_space)
+            for action_type, action_mask in obs.actions.items():
+                assert (
+                    action_type in action_space
+                ), f"Actions contain action of type '{action_type}' which is not in action space: {list(action_space.keys())}"
+                space = action_space[action_type]
+                if isinstance(space, CategoricalActionSpace):
+                    assert isinstance(
+                        action_mask, CategoricalActionMask
+                    ), f"Action of type '{action_type}' has invalid type: {type(action_mask)}. Expected: CategoricalActionMask"
+                    if action_mask.actor_ids is not None:
+                        for id in action_mask.actor_ids:
+                            assert (
+                                id in ids
+                            ), f"Action of type '{action_type}' contains invalid actor id {id} which is not in ids: {obs.ids}"
+                    if action_mask.actor_types is not None:
+                        for actor_type in action_mask.actor_types:
+                            assert (
+                                actor_type in obs.ids
+                            ), f"Action of type '{action_type}' contains invalid actor type {actor_type} which is not in ids: {obs.ids.keys()}"
+                    mask = action_mask.mask
+                    if isinstance(mask, np.ndarray):
+                        assert (
+                            mask.dtype == np.bool_
+                        ), f"Action of type '{action_type}' has invalid dtype: {mask.dtype}. Expected: {np.bool_}"
+                        shape = mask.shape
+                        actor_indices = obs._actor_indices(action_type, obs_space)
+                        assert shape == (
+                            len(actor_indices),
+                            len(space.choices),
+                        ), f"Action of type '{action_type}' has invalid shape: {shape}. Expected: ({len(actor_indices), len(space.choices)})"
+                        unmasked_count = mask.sum(axis=1)
+                        for i in range(len(unmasked_count)):
+                            assert (
+                                unmasked_count[i] > 0
+                            ), f"Action of type '{action_type}' contains invalid mask for {i}-th actor: {mask[i]}. Expected at least one possible action"
+                    elif mask is not None:
+                        assert len(mask) == len(
+                            actor_indices
+                        ), f"Action of type '{action_type}' has invalid length: {len(mask)}. Expected: {len(actor_indices)}"
+                        for i in range(len(mask)):
+                            assert len(mask[i]) == len(
+                                space.choices
+                            ), f"Action of type '{action_type}' has invalid length of mask for {i}-th actor: {len(mask[i])}. Expected: {len(space.choices)}"
+                            assert any(
+                                mask[i]
+                            ), f"Action of type '{action_type}' contains invalid mask for {i}-th actor: {mask[i]}. Expected at least one possible action"
+
+                elif isinstance(action_space[action_type], SelectEntityActionSpace):
+                    assert isinstance(
+                        action_mask, SelectEntityActionMask
+                    ), f"Action of type '{action_type}' has invalid type: {type(action_mask)}. Expected: SelectEntityActionMask"
+
+    return ValidatedEnv


### PR DESCRIPTION
Implements an environment wrapper, applied by default in `train.py`, which checks that the `Observation`s returned by an environment are valid. I did a quick check on the multisnake environment, and perf impact seems to be relatively low, though that could be different for environments with more entities and masks: https://wandb.ai/entity-neural-network/enn-ppo/reports/env-validate-perf-impact--VmlldzoxNjU3NTU0

Fixes https://github.com/entity-neural-network/incubator/issues/160
Fixes https://github.com/entity-neural-network/incubator/issues/181
Partial solution to https://github.com/entity-neural-network/incubator/issues/186