### PR TITLE
Add pre-commit utilities

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -66,69 +66,6 @@ jobs:
         run: |
           poetry run pre-commit run  --all-files
 
-  # mypy:
-  #   name: mypy
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.9, 3.8]
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     #----------------------------------------------
-  #     #  -----  install & configure poetry  -----
-  #     #----------------------------------------------
-  #     - name: Install Poetry
-  #       uses: snok/install-poetry@v1
-  #       with:
-  #         virtualenvs-create: true
-  #         virtualenvs-in-project: true
-  #         installer-parallel: true
-  #     #----------------------------------------------
-  #     #       load cached venv if cache exists
-  #     #----------------------------------------------
-  #     - name: Load cached venv
-  #       id: cached-poetry-dependencies
-  #       uses: actions/cache@v2
-  #       with:
-  #         path: .venv
-  #         key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-  #     #----------------------------------------------
-  #     # install dependencies if cache does not exist
-  #     #----------------------------------------------
-  #     - name: Install dependencies
-  #       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-  #       continue-on-error: true
-  #       run: poetry install --no-interaction --no-root
-  #     #----------------------------------------------
-  #     # install cuda related dependencies
-  #     #----------------------------------------------
-  #     - name: Install dependencies
-  #       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-  #       run: poetry run pip install torch
-  #     - name: Install dependencies
-  #       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-  #       run: poetry run pip install torch-scatter
-  #     #----------------------------------------------
-  #     # install your root project, if required
-  #     #----------------------------------------------
-  #     - name: Install library
-  #       run: poetry install --no-interaction
-  #     #----------------------------------------------
-  #     # format, type check, and test your code
-  #     #----------------------------------------------
-
-  #     - name: MyPy
-  #       run: |
-  #         poetry run mypy enn_zoo
-  #         poetry run mypy entity_gym
-  #         poetry run mypy rogue_net
-  #         poetry run mypy enn_ppo
-
   unit_test:
     name: unit test
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  black:
-    name: black
+  pre-commit:
+    name: pre-commit
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,72 +62,72 @@ jobs:
       # format, type check, and test your code
       #----------------------------------------------
 
-      - name: Black code formatting
+      - name: Run pre-commit utilities
         run: |
-          poetry run black --check --diff .
+          pre-commit run  --all-files
 
-  mypy:
-    name: mypy
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9, 3.8]
+  # mypy:
+  #   name: mypy
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.9, 3.8]
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        continue-on-error: true
-        run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install cuda related dependencies
-      #----------------------------------------------
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry run pip install torch
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry run pip install torch-scatter
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
-      - name: Install library
-        run: poetry install --no-interaction
-      #----------------------------------------------
-      # format, type check, and test your code
-      #----------------------------------------------
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     #----------------------------------------------
+  #     #  -----  install & configure poetry  -----
+  #     #----------------------------------------------
+  #     - name: Install Poetry
+  #       uses: snok/install-poetry@v1
+  #       with:
+  #         virtualenvs-create: true
+  #         virtualenvs-in-project: true
+  #         installer-parallel: true
+  #     #----------------------------------------------
+  #     #       load cached venv if cache exists
+  #     #----------------------------------------------
+  #     - name: Load cached venv
+  #       id: cached-poetry-dependencies
+  #       uses: actions/cache@v2
+  #       with:
+  #         path: .venv
+  #         key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+  #     #----------------------------------------------
+  #     # install dependencies if cache does not exist
+  #     #----------------------------------------------
+  #     - name: Install dependencies
+  #       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+  #       continue-on-error: true
+  #       run: poetry install --no-interaction --no-root
+  #     #----------------------------------------------
+  #     # install cuda related dependencies
+  #     #----------------------------------------------
+  #     - name: Install dependencies
+  #       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+  #       run: poetry run pip install torch
+  #     - name: Install dependencies
+  #       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+  #       run: poetry run pip install torch-scatter
+  #     #----------------------------------------------
+  #     # install your root project, if required
+  #     #----------------------------------------------
+  #     - name: Install library
+  #       run: poetry install --no-interaction
+  #     #----------------------------------------------
+  #     # format, type check, and test your code
+  #     #----------------------------------------------
 
-      - name: MyPy
-        run: |
-          poetry run mypy enn_zoo
-          poetry run mypy entity_gym
-          poetry run mypy rogue_net
-          poetry run mypy enn_ppo
+  #     - name: MyPy
+  #       run: |
+  #         poetry run mypy enn_zoo
+  #         poetry run mypy entity_gym
+  #         poetry run mypy rogue_net
+  #         poetry run mypy enn_ppo
 
   unit_test:
     name: unit test

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run pre-commit utilities
         run: |
-          pre-commit run  --all-files
+          poetry run pre-commit run  --all-files
 
   # mypy:
   #   name: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,43 @@
+repos:
+  # - repo: https://github.com/PyCQA/isort
+  #   rev: 5.10.1
+  #   hooks:
+  #     - id: isort
+  #       args:
+  #         - --profile=black
+  #         - --skip-glob=wandb/**/*
+  # - repo: https://github.com/myint/autoflake
+  #   rev: v1.4
+  #   hooks:
+  #     - id: autoflake
+  #       args:
+  #         - -r
+  #         - --exclude=wandb
+  #         - --in-place
+  #         - --remove-unused-variables
+  #         - --remove-all-unused-imports
+  - repo: https://github.com/python/black
+    rev: 21.12b0
+    hooks:
+      - id: black
+        args:
+          - --exclude=wandb
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: v2.1.0
+  #   hooks:
+  #     - id: codespell
+  #       args:
+  #         - --ignore-words-list=nd,reacher,thist,ths,magent
+  #         - --skip=docs/css/termynal.css,docs/js/termynal.js
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v0.910
+  #   hooks:
+  #     - id: mypy
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,18 +22,13 @@ repos:
       - id: black
         args:
           - --exclude=wandb
-  # - repo: https://github.com/codespell-project/codespell
-  #   rev: v2.1.0
-  #   hooks:
-  #     - id: codespell
-  #       args:
-  #         - --ignore-words-list=nd,reacher,thist,ths,magent
-  #         - --skip=docs/css/termynal.css,docs/js/termynal.js
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.910
-  #   hooks:
-  #     - id: mypy
-
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=nd,reacher,thist,ths,magent
+          - --skip=docs/css/termynal.css,docs/js/termynal.js
   - repo: local
     hooks:
       - id: mypy

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,7 +280,7 @@ However, the attention operation is applied to sequences of entities from the sa
 It is currently implemented by packing/padding the flattened embeddings into a (sequence, entity, feature) tensor that places all entities from the same timestep/environment into the same sequence.
 To do this, we compute three tensors:
 - the `index` determines which entity is placed at each position the packed tensor
-- the `batch` tells us what timestep/environment each entity came from, and is used to construct a mask that prevents attention from going across seperate timmesteps/environments
+- the `batch` tells us what timestep/environment each entity came from, and is used to construct a mask that prevents attention from going across separate timesteps/environments
 - the `inverse_index` is used to reconstruct the original flattened embedding tensor from the packed tensor
 
 <details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,18 +53,23 @@ libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-d
 
 [![asciicast](https://asciinema.org/a/452597.svg)](https://asciinema.org/a/452597)
 
-## Code Formatting
+## Code Style
 
-We use [Black](https://black.readthedocs.io/en/stable/) for code formatting.
-You can run the following to format all files:
+We use [Pre-commit](https://pre-commit.com/) to 
+<!-- * sort dependencies
+* remove unused variables and imports -->
+* format code using black (via `black`)
+* check word spelling (via `codespell`)
+* check typing (via `mypy`)
+
+You can run the following command to do these automatically:
 
 ```bash
-poetry run black .
+poetry run pre-commit run --all-files
 ```
 
-## Running MyPy and Tests
+## Running Tests
 
 ```bash
-poetry run dmypy run -- entity_gym enn_ppo rogue_net
 poetry run pytest .
 ```

--- a/enn_ppo/enn_ppo/ppo.py
+++ b/enn_ppo/enn_ppo/ppo.py
@@ -49,7 +49,7 @@ def ppo_loss(
     # TODO: we can reuse the mb_advantages across all actions that have the same number of actors
     # TODO: what's the correct way of combining loss from multiple actions/actors on the same timestep? should we split the advantages across actions/actors?
     with tracer.span("broadcast_advantages"):
-        # Brodcast the advantage value from each timestep to all actors/actions on that timestep
+        # Broadcast the advantage value from each timestep to all actors/actions on that timestep
         bc_mb_advantages = {
             action_name: advantages[
                 torch.tensor(

--- a/enn_zoo/enn_zoo/codecraft/codecraftnet/config.py
+++ b/enn_zoo/enn_zoo/codecraft/codecraftnet/config.py
@@ -414,7 +414,7 @@ class AdrConfig:
     initial_hardness: float = 0.0
     # Linearly increase task difficulty/map size
     linear_hardness: bool = False
-    # Maxiumum map area
+    # Maximum map area
     max_hardness: float = 150
     # Number of timesteps steps after which hardness starts to increase
     hardness_offset: float = 1e6

--- a/enn_zoo/enn_zoo/griddly/test_griddly_env.py
+++ b/enn_zoo/enn_zoo/griddly/test_griddly_env.py
@@ -45,7 +45,7 @@ def test_griddly_wrapper() -> None:
         "entity_2_variable",
     ]
 
-    # Check the action space is being created correctly fro the test environment
+    # Check the action space is being created correctly for the test environment
     action_space = env_class.action_space()
     assert isinstance(action_space["move_one"], CategoricalActionSpace)
     assert action_space["move_one"].choices == [

--- a/entity_gym/entity_gym/environment/environment.py
+++ b/entity_gym/entity_gym/environment/environment.py
@@ -38,7 +38,7 @@ ActionSpace = Union[CategoricalActionSpace, SelectEntityActionSpace]
 class CategoricalActionMask:
     """
     Action mask for categorical action that specifies which agents can perform the action,
-    and includes a dense mask that further contraints the choices available to each agent.
+    and includes a dense mask that further constraints the choices available to each agent.
     """
 
     actor_ids: Optional[Sequence[EntityID]] = None
@@ -69,7 +69,7 @@ class CategoricalActionMask:
 class SelectEntityActionMask:
     """
     Action mask for select entity action that specifies which agents can perform the action,
-    and includes a dense mask that further contraints what other entities can be selected by
+    and includes a dense mask that further constraints what other entities can be selected by
     each actor.
     """
 

--- a/entity_gym/entity_gym/environment/parallel_env_list.py
+++ b/entity_gym/entity_gym/environment/parallel_env_list.py
@@ -47,7 +47,7 @@ class CloudpickleWrapper:
 
 class MsgpackConnectionWrapper(object):
     """
-    Use msgpack instead of pickle to send and recieve data from workers.
+    Use msgpack instead of pickle to send and receive data from workers.
     """
 
     def __init__(self, conn: Connection) -> None:

--- a/entity_gym/entity_gym/examples/cherry_pick.py
+++ b/entity_gym/entity_gym/examples/cherry_pick.py
@@ -21,7 +21,7 @@ from entity_gym.environment import (
 @dataclass
 class CherryPick(Environment):
     """
-    The CherryPick environment is initalized with a list of 32 cherries of random quality.
+    The CherryPick environment is initialized with a list of 32 cherries of random quality.
     On each timestep, the player can pick up one of the cherries.
     The player receives a reward of the quality of the cherry picked.
     The environment ends after 16 steps.

--- a/entity_gym/entity_gym/examples/pick_matching_balls.py
+++ b/entity_gym/entity_gym/examples/pick_matching_balls.py
@@ -27,7 +27,7 @@ class Ball:
 @dataclass
 class PickMatchingBalls(Environment):
     """
-    The PickMatchingBalls environment is initalized with a list of 32 balls of different colors.
+    The PickMatchingBalls environment is initialized with a list of 32 balls of different colors.
     On each timestamp, the player can pick up one of the balls.
     The episode ends when the player picks up a ball of a different color from the last one.
     The player receives a reward equal to the number of balls picked up divided by the maximum number of balls of the same color.

--- a/entity_gym/entity_gym/examples/xor.py
+++ b/entity_gym/entity_gym/examples/xor.py
@@ -36,7 +36,7 @@ class Xor(Environment):
     """
     There are three entities types, each with one instance on each timstep.
     The Bit1 and Bit2 entities are randomly set to 0 or 1.
-    The Ouput entity has one action that should be set to the output of the XOR between the two bits.
+    The Output entity has one action that should be set to the output of the XOR between the two bits.
     """
 
     @classmethod

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,6 +126,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.3.1"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -244,6 +252,14 @@ python-versions = ">=2.7, !=3.0.*"
 graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
+name = "distlib"
+version = "0.3.4"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "docker-pycreds"
 version = "0.4.0"
 description = "Python bindings for the docker credentials store API"
@@ -339,6 +355,18 @@ description = "Get the currently executing AST node of a frame, and other inform
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "filelock"
+version = "3.6.0"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
 name = "gitdb"
@@ -491,6 +519,17 @@ docstring-parser = ">=0.13,<0.14"
 msgpack = ">=1.0.3,<2.0.0"
 msgpack-numpy = ">=0.4.7,<0.5.0"
 python-ron = ">=0.1.6,<0.2.0"
+
+[[package]]
+name = "identify"
+version = "2.4.11"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -766,6 +805,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nodeenv"
+version = "1.6.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "numpy"
 version = "1.22.3"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -931,6 +978,22 @@ python-versions = ">=3.6"
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "2.17.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+toml = "*"
+virtualenv = ">=20.0.8"
 
 [[package]]
 name = "prettytable"
@@ -1465,6 +1528,24 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.13.3"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+distlib = ">=0.3.1,<1"
+filelock = ">=3.2,<4"
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
 name = "wandb"
 version = "0.12.11"
 description = "A CLI and library for interacting with the Weights and Biases API."
@@ -1544,7 +1625,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "550c8e8f20cfccb7fe2c0b9540e2c823075a23d368190b1e80a0b49dbe9e6c3d"
+content-hash = "53bee2a0a70abc8f55dd6faec308f3ce6f214a4eb22c0d178d71e4a0e63a044f"
 
 [metadata.files]
 absl-py = [
@@ -1591,6 +1672,10 @@ certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
+cfgv = [
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
@@ -1631,6 +1716,10 @@ dill = [
     {file = "dill-0.3.4-py2.py3-none-any.whl", hash = "sha256:7e40e4a70304fd9ceab3535d36e58791d9c4a776b38ec7f7ec9afc8d3dca4d4f"},
     {file = "dill-0.3.4.zip", hash = "sha256:9f9734205146b2b353ab3fec9af0070237b6ddae78452af83d2fca84d739e675"},
 ]
+distlib = [
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
 docker-pycreds = [
     {file = "docker-pycreds-0.4.0.tar.gz", hash = "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4"},
     {file = "docker_pycreds-0.4.0-py2.py3-none-any.whl", hash = "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49"},
@@ -1644,6 +1733,10 @@ entity-gym = []
 executing = [
     {file = "executing-0.8.3-py2.py3-none-any.whl", hash = "sha256:d1eef132db1b83649a3905ca6dd8897f71ac6f8cac79a7e58a1a09cf137546c9"},
     {file = "executing-0.8.3.tar.gz", hash = "sha256:c6554e21c6b060590a6d3be4b82fb78f8f0194d809de5ea7df1c093763311501"},
+]
+filelock = [
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
 ]
 gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
@@ -1784,6 +1877,10 @@ gym-microrts = [
 hyperstate = [
     {file = "hyperstate-0.2.7-py3-none-any.whl", hash = "sha256:c6f74760375aef6fb7c199aca4f11f5bdace0e18546b8ad616bd7c7a29dbf2cf"},
     {file = "hyperstate-0.2.7.tar.gz", hash = "sha256:67081aac86aed2a03657fc486a932fac9bc5a5f8aea0e28b8e4e70abdad7ef72"},
+]
+identify = [
+    {file = "identify-2.4.11-py2.py3-none-any.whl", hash = "sha256:fd906823ed1db23c7a48f9b176a1d71cb8abede1e21ebe614bac7bdd688d9213"},
+    {file = "identify-2.4.11.tar.gz", hash = "sha256:2986942d3974c8f2e5019a190523b0b0e2a07cb8e89bf236727fb4b26f27f8fd"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1971,6 +2068,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.6.0-py2.py3-none-any.whl", hash = "sha256:621e6b7076565ddcacd2db0294c0381e01fd28945ab36bcf00f41c5daf63bef7"},
+    {file = "nodeenv-1.6.0.tar.gz", hash = "sha256:3ef13ff90291ba2a4a7a4ff9a979b63ffdd00a464dbe04acf0ea6471517a4c2b"},
+]
 numpy = [
     {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
     {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
@@ -2105,6 +2206,10 @@ platformdirs = [
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pre-commit = [
+    {file = "pre_commit-2.17.0-py2.py3-none-any.whl", hash = "sha256:725fa7459782d7bec5ead072810e47351de01709be838c2ce1726b9591dad616"},
+    {file = "pre_commit-2.17.0.tar.gz", hash = "sha256:c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a"},
 ]
 prettytable = [
     {file = "prettytable-3.2.0-py3-none-any.whl", hash = "sha256:f6c5ec87c3ef9df5bba1d32d826c1b862ecad0344dddb6082e3562caf71fe085"},
@@ -2476,6 +2581,10 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
+]
+virtualenv = [
+    {file = "virtualenv-20.13.3-py2.py3-none-any.whl", hash = "sha256:dd448d1ded9f14d1a4bfa6bfc0c5b96ae3be3f2d6c6c159b23ddcfd701baa021"},
+    {file = "virtualenv-20.13.3.tar.gz", hash = "sha256:e9dd1a1359d70137559034c0f5433b34caf504af2dc756367be86a5a32967134"},
 ]
 wandb = [
     {file = "wandb-0.12.11-py2.py3-none-any.whl", hash = "sha256:3a8637ae1b580d5839bde4792d9c31ecd40392ae8a245874391edd82c74e7b17"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ black = "^21.11b1"
 pytest = "^6.2.5"
 mypy = "^0.910"
 ipdb = "^0.13.9"
+pre-commit = "^2.17.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This PR introduces pre-commit pipelines, which include

* black: auto-format
* codespell: check word spelling
* mypy

going to add the following hooks in a follow-up PR:

* isort: automatically sort imported dependencies
* autoflake: automatically remove unused variables and unused imports

However, it does keep the tests alone because they run slow: see https://github.com/pre-commit/pre-commit-hooks/issues/291