### PR TITLE
Eliminate EpisodeStats

### DIFF
--- a/enn_ppo/enn_ppo/eval.py
+++ b/enn_ppo/enn_ppo/eval.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Mapping, Tuple, Type, Union
+from typing import Callable, List, Mapping, Optional, Tuple, Type, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -6,6 +6,7 @@ import torch
 from torch.utils.tensorboard import SummaryWriter
 
 from enn_ppo.agent import PPOAgent
+from entity_gym.environment.add_metrics_wrapper import AddMetricsWrapper
 from enn_ppo.config import EnvConfig, EvalConfig, RolloutConfig
 from enn_ppo.rollout import Rollout
 from entity_gym.environment import *
@@ -31,10 +32,10 @@ def run_eval(
     # TODO: metrics are biased towards short episodes
     processes = cfg.processes or rollout.processes
     num_envs = cfg.num_envs or rollout.num_envs
-    envs = create_env(env_cfg, num_envs, processes)
     obs_space = env_cls.obs_space()
     action_space = env_cls.action_space()
 
+    metric_filter: Optional[npt.NDArray[np.bool8]] = None
     if cfg.opponent is not None:
         opponent = create_opponent(cfg.opponent, obs_space, action_space, device)
         if cfg.opponent_only:
@@ -49,8 +50,13 @@ def run_eval(
                     opponent,
                 ),
             ]
+            metric_filter = np.arange(num_envs) % 2 == 0
     else:
         agents = agent
+
+    envs: VecEnv = AddMetricsWrapper(
+        create_env(env_cfg, num_envs, processes), metric_filter
+    )
 
     if cfg.capture_samples:
         envs = SampleRecordingVecEnv(

--- a/enn_ppo/enn_ppo/rollout.py
+++ b/enn_ppo/enn_ppo/rollout.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Mapping, Optional, Tuple, Union
+from entity_gym.environment.vec_env import Metric
 
 import numpy as np
 import numpy.typing as npt
@@ -54,7 +55,7 @@ class Rollout:
         record_samples: bool,
         capture_videos: bool = False,
         capture_logits: bool = False,
-    ) -> Tuple[VecObs, torch.Tensor, Dict[str, float]]:
+    ) -> Tuple[VecObs, torch.Tensor, Dict[str, Metric]]:
         """
         Run the agent for a number of steps. Returns next_obs, next_done, and a dictionary of statistics.
         """
@@ -76,10 +77,7 @@ class Rollout:
         else:
             invindex = np.array([], dtype=np.int64)
 
-        total_episodic_return = 0.0
-        total_episodic_length = 0
-        total_metrics = {}
-        total_episodes = 0
+        metrics: Dict[str, Metric] = {}
 
         if self.next_obs is None or self.next_done is None:
             next_obs = self.envs.reset(self.obs_space)
@@ -186,23 +184,11 @@ class Rollout:
                     )
                     next_done = torch.tensor(next_obs.done).to(self.device).view(-1)
 
-            if isinstance(self.agent, list):
-                end_of_episode_infos = []
-                for i in self.agent[0][0]:
-                    if i in next_obs.end_of_episode_info:
-                        end_of_episode_infos.append(next_obs.end_of_episode_info[i])
-            else:
-                end_of_episode_infos = list(next_obs.end_of_episode_info.values())
-            for eoei in end_of_episode_infos:
-                total_episodic_return += eoei.total_reward
-                total_episodic_length += eoei.length
-                total_episodes += 1
-                if eoei.metrics is not None:
-                    for k, v in eoei.metrics.items():
-                        if k not in total_metrics:
-                            total_metrics[k] = v
-                        else:
-                            total_metrics[k] += v
+            for mname, mvalue in next_obs.metrics.items():
+                if mname in metrics:
+                    metrics[mname] += mvalue
+                else:
+                    metrics[mname] = mvalue
 
         self.next_obs = next_obs
         self.next_done = next_done
@@ -210,14 +196,4 @@ class Rollout:
         if capture_videos:
             self.rendered = np.stack(self.rendered_frames)
 
-        metrics = {}
-        if total_episodes > 0:
-            avg_return = total_episodic_return / total_episodes
-            avg_length = total_episodic_length / total_episodes
-            metrics["charts/episodic_return"] = avg_return
-            metrics["charts/episodic_length"] = avg_length
-            metrics["charts/episodes"] = total_episodes
-            metrics["meanrew"] = self.rewards.mean().item()
-            for k, v in total_metrics.items():
-                metrics[f"metrics/{k}/avg"] = v / total_episodes
         return next_obs, next_done, metrics

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Callable, Dict, Mapping, Optional, Type
+from entity_gym.environment.add_metrics_wrapper import AddMetricsWrapper
 
 import hyperstate
 import numpy as np
@@ -128,7 +129,9 @@ def train(
 
     if create_env is None:
         create_env = _env_factory(env_cls)
-    envs = create_env(cfg.env, cfg.rollout.num_envs, cfg.rollout.processes)
+    envs: VecEnv = AddMetricsWrapper(
+        create_env(cfg.env, cfg.rollout.num_envs, cfg.rollout.processes)
+    )
     obs_space = env_cls.obs_space()
     action_space = env_cls.action_space()
 
@@ -246,9 +249,30 @@ def train(
             cfg.rollout.steps, record_samples=True, capture_logits=cfg.capture_logits
         )
         for name, value in metrics.items():
-            writer.add_scalar(name, value, rollout.global_step)
+            writer.add_scalar(name + "/mean", value.mean, rollout.global_step)
+            writer.add_scalar(name + "/min", value.min, rollout.global_step)
+            writer.add_scalar(name + "/max", value.max, rollout.global_step)
+            writer.add_scalar(name + "/count", value.count, rollout.global_step)
+
+        # Double log these to remain compatible with old naming scheme
+        # TODO: remove before release
+        writer.add_scalar(
+            "charts/episodic_return",
+            metrics["episodic/reward"].mean,
+            rollout.global_step,
+        )
+        writer.add_scalar(
+            "charts/episodic_length",
+            metrics["episodic/length"].mean,
+            rollout.global_step,
+        )
+        writer.add_scalar(
+            "charts/episodes", metrics["episodic/reward"].count, rollout.global_step
+        )
+        writer.add_scalar("meanrew", metrics["reward"].mean, rollout.global_step)
+
         print(
-            f"global_step={rollout.global_step} {'  '.join(f'{name}={value}' for name, value in metrics.items())}"
+            f"global_step={rollout.global_step} {'  '.join(f'{name}={value.mean}' for name, value in metrics.items())}"
         )
 
         values = rollout.values
@@ -394,7 +418,6 @@ def train(
         var_y = np.var(y_true)
         explained_var = np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y
 
-        # TRY NOT TO MODIFY: record rewards for plotting purposes
         writer.add_scalar(
             "charts/learning_rate", optimizer.param_groups[0]["lr"], global_step
         )

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -249,25 +249,25 @@ def train(
             cfg.rollout.steps, record_samples=True, capture_logits=cfg.capture_logits
         )
         for name, value in metrics.items():
-            writer.add_scalar(name + "/mean", value.mean, rollout.global_step)
-            writer.add_scalar(name + "/min", value.min, rollout.global_step)
-            writer.add_scalar(name + "/max", value.max, rollout.global_step)
-            writer.add_scalar(name + "/count", value.count, rollout.global_step)
+            writer.add_scalar(f"{name}.mean", value.mean, rollout.global_step)
+            writer.add_scalar(f"{name}.max", value.max, rollout.global_step)
+            writer.add_scalar(f"{name}.min", value.min, rollout.global_step)
+            writer.add_scalar(f"{name}.count", value.count, rollout.global_step)
 
         # Double log these to remain compatible with old naming scheme
         # TODO: remove before release
         writer.add_scalar(
             "charts/episodic_return",
-            metrics["episodic/reward"].mean,
+            metrics["episodic_reward"].mean,
             rollout.global_step,
         )
         writer.add_scalar(
             "charts/episodic_length",
-            metrics["episodic/length"].mean,
+            metrics["episode_length"].mean,
             rollout.global_step,
         )
         writer.add_scalar(
-            "charts/episodes", metrics["episodic/reward"].count, rollout.global_step
+            "charts/episodes", metrics["episodic_reward"].count, rollout.global_step
         )
         writer.add_scalar("meanrew", metrics["reward"].mean, rollout.global_step)
 

--- a/enn_zoo/enn_zoo/griddly_env/wrapper.py
+++ b/enn_zoo/enn_zoo/griddly_env/wrapper.py
@@ -9,7 +9,6 @@ from entity_gym.environment import (
     ActionSpace,
     CategoricalActionMask,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -101,26 +100,15 @@ class GriddlyEnv(Environment):
             actions=action_masks,
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, self.total_reward)
-            if done
-            else None,
         )
 
     def reset(self) -> Observation:
         self._env.reset()
-
-        self.total_reward = 0
-        self.step = 0
-
         return self._make_observation()
 
     def act(self, action: Mapping[str, Action]) -> Observation:
         g_action = self._to_griddly_action(action)
         _, reward, done, info = self._env.step(g_action)
-
-        self.total_reward += reward
-        self.step += 1
-
         return self._make_observation(reward, done)
 
     def render(self, **kwargs: Any) -> npt.NDArray[np.uint8]:

--- a/enn_zoo/enn_zoo/microrts/__init__.py
+++ b/enn_zoo/enn_zoo/microrts/__init__.py
@@ -21,7 +21,6 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     Entity,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -232,11 +231,6 @@ class GymMicrorts(Environment):
             },
             reward=response.reward @ self.reward_weight,
             done=response.done[0],
-            end_of_episode_info=EpisodeStats(
-                length=self.step, total_reward=float(self.reward_weight @ self.returns)
-            )
-            if response.done[0]
-            else None,
         )
 
     def act(self, action: Mapping[str, Action]) -> Observation:
@@ -308,18 +302,12 @@ class GymMicrorts(Environment):
             },
             reward=response.reward @ self.reward_weight,
             done=response.done[0],
-            end_of_episode_info=EpisodeStats(
-                length=self.step,
-                total_reward=float(self.reward_weight @ self.returns),
-                metrics=dict(
-                    zip(
-                        [f"charts/episodic_return/{item}" for item in self.rfs_names],
-                        self.returns,
-                    )
-                ),
-            )
-            if response.done[0]
-            else None,
+            metrics=dict(
+                zip(
+                    [f"charts/episodic_return/{item}" for item in self.rfs_names],
+                    self.returns,
+                )
+            ),
         )
 
     def generate_entities(self, response: Any) -> Mapping[str, Optional[EntityObs]]:

--- a/enn_zoo/enn_zoo/train.py
+++ b/enn_zoo/enn_zoo/train.py
@@ -10,12 +10,11 @@ import web_pdb
 import enn_ppo.config as config
 from enn_ppo.agent import PPOAgent
 from enn_ppo.train import train
-from enn_zoo import griddly_env, vizdoom_env
+from enn_zoo import griddly_env
 from enn_zoo.codecraft.cc_vec_env import CodeCraftVecEnv, codecraft_env_class
 from enn_zoo.codecraft.codecraftnet.adapter import CCNetAdapter
 from enn_zoo.griddly_env import GRIDDLY_ENVS
 from enn_zoo.microrts import GymMicrorts
-from enn_zoo.vizdoom_env import VIZDOOM_ENVS
 from entity_gym.environment import *
 from entity_gym.examples import ENV_REGISTRY
 from rogue_net.rogue_net import RogueNet, RogueNetConfig
@@ -71,12 +70,16 @@ def main(cfg: TrainConfig) -> None:
         env_cls = codecraft_env_class(objective, hidden_obs)
     elif cfg.env.id == "GymMicrorts":
         env_cls = GymMicrorts
-    elif cfg.env.id in VIZDOOM_ENVS:
-        env_cls = vizdoom_env.create_vizdoom_env(VIZDOOM_ENVS[cfg.env.id])
     else:
-        raise KeyError(
-            f"Unknown gym_id: {cfg.env.id}\nAvailable environments: {list(ENV_REGISTRY.keys()) + list(GRIDDLY_ENVS.keys()) + ['CodeCraft']}"
-        )
+        try:
+            from enn_zoo.vizdoom_env import VIZDOOM_ENVS
+            from enn_zoo import vizdoom_env
+
+            env_cls = vizdoom_env.create_vizdoom_env(VIZDOOM_ENVS[cfg.env.id])
+        except ImportError:
+            raise KeyError(
+                f"Unknown gym_id: {cfg.env.id}\nAvailable environments: {list(ENV_REGISTRY.keys()) + list(GRIDDLY_ENVS.keys()) + ['CodeCraft']}"
+            )
 
     agent: Optional[PPOAgent] = None
     if cfg.codecraft_net:

--- a/enn_zoo/enn_zoo/vizdoom_env/vizdoom_environment.py
+++ b/enn_zoo/enn_zoo/vizdoom_env/vizdoom_environment.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Mapping, Set, Union
 
 import numpy as np
 import numpy.typing as npt
+
 import vizdoom as vzd  # type: ignore
 
 from entity_gym.environment import (

--- a/entity_gym/entity_gym/environment/__init__.py
+++ b/entity_gym/entity_gym/environment/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
     "CategoricalActionMask",
     "SelectEntityActionMask",
     "ObsSpace",
-    "EpisodeStats",
     "Entity",
     "EntityType",
     "ActionType",

--- a/entity_gym/entity_gym/environment/add_metrics_wrapper.py
+++ b/entity_gym/entity_gym/environment/add_metrics_wrapper.py
@@ -50,13 +50,19 @@ class AddMetricsWrapper(VecEnv):
         self.total_steps += 1
         episodic_reward = Metric()
         episodic_length = Metric()
+        obs.metrics["step"] = Metric(
+            sum=self.total_steps.sum(),
+            count=len(self.total_steps),
+            min=self.total_steps.min(),
+            max=self.total_steps.max(),
+        )
         for i in np.arange(len(self))[obs.done & self.filter]:
             episodic_reward.push(self.total_reward[i])
             episodic_length.push(self.total_steps[i])
             self.total_reward[i] = 0.0
             self.total_steps[i] = 0
-        obs.metrics["episodic/reward"] = episodic_reward
-        obs.metrics["episodic/length"] = episodic_length
+        obs.metrics["episodic_reward"] = episodic_reward
+        obs.metrics["episode_length"] = episodic_length
         obs.metrics["reward"] = Metric(
             sum=obs.reward.sum(),
             count=obs.reward.size,

--- a/entity_gym/entity_gym/environment/add_metrics_wrapper.py
+++ b/entity_gym/entity_gym/environment/add_metrics_wrapper.py
@@ -1,0 +1,66 @@
+from typing import Any, Mapping, Optional, Type
+from entity_gym.environment.environment import ActionType, Environment, ObsSpace
+from entity_gym.environment.vec_env import Metric, VecEnv, VecObs
+
+import numpy as np
+import numpy.typing as npt
+from ragged_buffer import RaggedBufferI64
+
+
+class AddMetricsWrapper(VecEnv):
+    def __init__(
+        self, env: VecEnv, filter: Optional[npt.NDArray[np.bool8]] = None
+    ) -> None:
+        """
+        Wrap a VecEnv to track and add metrics for (episodic) rewards and episode lengths.
+
+        Args:
+            env: The VecEnv to wrap.
+            filter: A boolean array of length len(env) indicating which environments to
+                track metrics for. If filter[i] is True, then the metrics for the i-th
+                environment will be tracked.
+        """
+        self.env = env
+        self.total_reward = np.zeros(len(env), dtype=np.float32)
+        self.total_steps = np.zeros(len(env), dtype=np.int64)
+        self.filter = filter or np.ones(len(env), dtype=np.bool8)
+
+    def env_cls(self) -> Type[Environment]:
+        return self.env.env_cls()
+
+    def reset(self, obs_config: ObsSpace) -> VecObs:
+        return self.track_metrics(self.env.reset(obs_config))
+
+    def act(
+        self, actions: Mapping[ActionType, RaggedBufferI64], obs_filter: ObsSpace
+    ) -> VecObs:
+        return self.track_metrics(self.env.act(actions, obs_filter))
+
+    def render(self, **kwargs: Any) -> npt.NDArray[np.uint8]:
+        return self.env.render(**kwargs)
+
+    def __len__(self) -> int:
+        return len(self.env)
+
+    def close(self) -> None:
+        self.env.close()
+
+    def track_metrics(self, obs: VecObs) -> VecObs:
+        self.total_reward += obs.reward
+        self.total_steps += 1
+        episodic_reward = Metric()
+        episodic_length = Metric()
+        for i in np.arange(len(self))[obs.done & self.filter]:
+            episodic_reward.push(self.total_reward[i])
+            episodic_length.push(self.total_steps[i])
+            self.total_reward[i] = 0.0
+            self.total_steps[i] = 0
+        obs.metrics["episodic/reward"] = episodic_reward
+        obs.metrics["episodic/length"] = episodic_length
+        obs.metrics["reward"] = Metric(
+            sum=obs.reward.sum(),
+            count=obs.reward.size,
+            min=obs.reward.min(),
+            max=obs.reward.max(),
+        )
+        return obs

--- a/entity_gym/entity_gym/environment/env_list.py
+++ b/entity_gym/entity_gym/environment/env_list.py
@@ -99,7 +99,7 @@ class EnvList(VecEnv):
                 new_obs = env.reset_filter(obs_space)
                 new_obs.done = True
                 new_obs.reward = obs.reward
-                new_obs.end_of_episode_info = obs.end_of_episode_info
+                new_obs.metrics = obs.metrics
                 observations.append(new_obs)
             else:
                 observations.append(obs)

--- a/entity_gym/entity_gym/environment/environment.py
+++ b/entity_gym/entity_gym/environment/environment.py
@@ -117,13 +117,6 @@ ActionMask = Union[CategoricalActionMask, SelectEntityActionMask]
 
 
 @dataclass
-class EpisodeStats:
-    length: int
-    total_reward: float
-    metrics: Optional[Dict[str, float]] = None
-
-
-@dataclass
 class Entity:
     features: List[str]
 
@@ -165,7 +158,7 @@ class Observation:
     visible: Mapping[EntityType, Union[npt.NDArray[np.bool_], Sequence[bool]]] = field(
         default_factory=dict
     )
-    end_of_episode_info: Optional[EpisodeStats] = None
+    metrics: Dict[str, float] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self._id_to_index: Optional[Dict[EntityID, int]] = None
@@ -178,7 +171,7 @@ class Observation:
         actions: Mapping[ActionType, ActionMask],
         done: bool,
         reward: float,
-        end_of_episode_info: Optional[EpisodeStats] = None,
+        metrics: Optional[Dict[str, float]] = None,
     ) -> "Observation":
         return cls(
             features={
@@ -194,7 +187,7 @@ class Observation:
                 for etype, entity in entities.items()
                 if entity is not None and entity.ids is not None
             },
-            end_of_episode_info=end_of_episode_info,
+            metrics=metrics or {},
         )
 
     def _actor_indices(
@@ -370,7 +363,7 @@ class Environment(ABC):
             done=obs.done,
             reward=obs.reward,
             ids=obs.ids,
-            end_of_episode_info=obs.end_of_episode_info,
+            metrics=obs.metrics,
         )
 
     @classmethod

--- a/entity_gym/entity_gym/environment/vec_env.py
+++ b/entity_gym/entity_gym/environment/vec_env.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Type, Union, overload
+import copy
 
 import numpy as np
 import numpy.typing as npt
@@ -12,7 +13,6 @@ from entity_gym.environment.environment import (
     CategoricalActionSpace,
     EntityType,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
     SelectEntityActionSpace,
@@ -106,6 +106,42 @@ VecActionMask = Union[VecCategoricalActionMask, VecSelectEntityActionMask]
 
 
 @dataclass
+class Metric:
+    count: int = 0
+    sum: float = 0.0
+    min: float = float("-inf")
+    max: float = float("inf")
+
+    def push(self, value: float) -> None:
+        self.count += 1
+        self.sum += value
+        self.min = min(self.min, value)
+        self.max = max(self.max, value)
+    
+    def __iadd__(self, m: "Metric") -> "Metric":
+        self.count += m.count
+        self.sum += m.sum
+        self.min = min(self.min, m.min)
+        self.max = max(self.max, m.max)
+        return self
+    
+    def __add__(self, m: "Metric") -> "Metric":
+        return Metric(
+            count=self.count + m.count,
+            sum=self.sum + m.sum,
+            min=min(self.min, m.min),
+            max=max(self.max, m.max),
+        )
+
+    @property
+    def mean(self) -> float:
+        if self.count == 0:
+            return 0.0
+        else:
+            return self.sum / self.count
+
+
+@dataclass
 class VecObs:
     features: Dict[EntityType, RaggedBufferF32]
     # Optional mask to hide specific entities from the policy but not the value function
@@ -113,7 +149,7 @@ class VecObs:
     action_masks: Dict[ActionType, VecActionMask]
     reward: npt.NDArray[np.float32]
     done: npt.NDArray[np.bool_]
-    end_of_episode_info: Dict[int, EpisodeStats]
+    metrics: Dict[str, Metric]
 
     def extend(self, b: "VecObs") -> None:
         num_envs = len(self.reward)
@@ -134,8 +170,14 @@ class VecObs:
         self.reward = np.concatenate((self.reward, b.reward))
         self.done = np.concatenate((self.done, b.done))
         num_envs = len(self.reward)
-        for i, stats in b.end_of_episode_info.items():
-            self.end_of_episode_info[i + num_envs] = stats
+        for name, stats in b.metrics.items():
+            if name in self.metrics:
+                self.metrics[name].count += stats.count
+                self.metrics[name].sum += stats.sum
+                self.metrics[name].min = min(self.metrics[name].min, stats.min)
+                self.metrics[name].max = max(self.metrics[name].max, stats.max)
+            else:
+                self.metrics[name] = copy.copy(stats)
         for etype in self.features.keys():
             if etype in b.visible:
                 if etype not in self.visible:
@@ -198,7 +240,7 @@ def batch_obs(
     action_masks: Dict[ActionType, VecActionMask] = {}
     reward = []
     done = []
-    end_of_episode_info = {}
+    metrics = {}
 
     # Initialize the entire batch with all entities and actions
     for entity_name, entity in obs_space.entities.items():
@@ -315,8 +357,10 @@ def batch_obs(
 
         reward.append(o.reward)
         done.append(o.done)
-        if o.end_of_episode_info:
-            end_of_episode_info[len(reward) - 1] = o.end_of_episode_info
+        for name, value in o.metrics.items():
+            if name not in metrics:
+                metrics[name] = Metric()
+            metrics[name].push(value)
 
     return VecObs(
         features,
@@ -324,7 +368,7 @@ def batch_obs(
         action_masks,
         np.array(reward, dtype=np.float32),
         np.array(done, dtype=np.bool_),
-        end_of_episode_info,
+        metrics,
     )
 
 

--- a/entity_gym/entity_gym/environment/vec_env.py
+++ b/entity_gym/entity_gym/environment/vec_env.py
@@ -109,8 +109,8 @@ VecActionMask = Union[VecCategoricalActionMask, VecSelectEntityActionMask]
 class Metric:
     count: int = 0
     sum: float = 0.0
-    min: float = float("-inf")
-    max: float = float("inf")
+    min: float = float("inf")
+    max: float = float("-inf")
 
     def push(self, value: float) -> None:
         self.count += 1

--- a/entity_gym/entity_gym/examples/cherry_pick.py
+++ b/entity_gym/entity_gym/examples/cherry_pick.py
@@ -9,7 +9,6 @@ from entity_gym.environment import (
     Entity,
     EntityID,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
     SelectEntityAction,
@@ -79,9 +78,6 @@ class CherryPick(Environment):
             },
             reward=self.last_reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, self.total_reward)
-            if done
-            else None,
         )
 
     def act(self, action: Mapping[str, Action]) -> Observation:

--- a/entity_gym/entity_gym/examples/count.py
+++ b/entity_gym/entity_gym/examples/count.py
@@ -13,7 +13,6 @@ from entity_gym.environment import (
     CategoricalActionMask,
     CategoricalActionSpace,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -115,5 +114,4 @@ class Count(Environment):
             },
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(1, reward) if done else None,
         )

--- a/entity_gym/entity_gym/examples/floor_is_lava.py
+++ b/entity_gym/entity_gym/examples/floor_is_lava.py
@@ -10,7 +10,6 @@ from entity_gym.environment import (
     CategoricalActionMask,
     CategoricalActionSpace,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -124,5 +123,4 @@ class FloorIsLava(Environment):
             ids={"Player": [0]},
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(1, reward) if done else None,
         )

--- a/entity_gym/entity_gym/examples/minefield.py
+++ b/entity_gym/entity_gym/examples/minefield.py
@@ -12,7 +12,6 @@ from entity_gym.environment import (
     CategoricalActionMask,
     CategoricalActionSpace,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -170,5 +169,4 @@ class Minefield(Environment):
             ids={"Vehicle": ["Vehicle"]},
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, reward) if done else None,
         )

--- a/entity_gym/entity_gym/examples/minesweeper.py
+++ b/entity_gym/entity_gym/examples/minesweeper.py
@@ -102,7 +102,6 @@ class MineSweeper(Environment):
             done=done,
             # Give reward of 1.0 for defusing all mines
             reward=reward,
-            end_of_episode_info=EpisodeStats(10, reward) if done else None,
         )
 
     def act(self, actions: Mapping[ActionType, Action]) -> Observation:

--- a/entity_gym/entity_gym/examples/move_to_origin.py
+++ b/entity_gym/entity_gym/examples/move_to_origin.py
@@ -12,7 +12,6 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     Entity,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -142,10 +141,4 @@ class MoveToOrigin(Environment):
             reward=(self.last_x_pos ** 2 + self.last_y_pos ** 2) ** 0.5
             - (self.x_pos ** 2 + self.y_pos ** 2) ** 0.5,
             done=done,
-            end_of_episode_info=EpisodeStats(
-                length=self.step,
-                total_reward=1 - (self.x_pos ** 2 + self.y_pos ** 2) ** 0.5,
-            )
-            if done
-            else None,
         )

--- a/entity_gym/entity_gym/examples/multi_armed_bandit.py
+++ b/entity_gym/entity_gym/examples/multi_armed_bandit.py
@@ -11,7 +11,6 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     Entity,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -73,7 +72,4 @@ class MultiArmedBandit(Environment):
             ids={"MultiArmedBandit": [0]},
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, self._total_reward)
-            if done
-            else None,
         )

--- a/entity_gym/entity_gym/examples/multi_snake.py
+++ b/entity_gym/entity_gym/examples/multi_snake.py
@@ -13,7 +13,6 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     Entity,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -221,9 +220,4 @@ class MultiSnake(Environment):
             },
             reward=self.scores[player] - self.last_scores[player],
             done=done,
-            end_of_episode_info=EpisodeStats(
-                length=self.step, total_reward=self.scores[player]
-            )
-            if done
-            else None,
         )

--- a/entity_gym/entity_gym/examples/not_hotdog.py
+++ b/entity_gym/entity_gym/examples/not_hotdog.py
@@ -12,7 +12,6 @@ from entity_gym.environment import (
     CategoricalActionSpace,
     Entity,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -93,5 +92,4 @@ class NotHotdog(Environment):
             ids={"Player": [0]},
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, reward) if done else None,
         )

--- a/entity_gym/entity_gym/examples/pick_matching_balls.py
+++ b/entity_gym/entity_gym/examples/pick_matching_balls.py
@@ -9,7 +9,6 @@ from entity_gym.environment import (
     ActionSpace,
     Entity,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
     SelectEntityAction,
@@ -70,7 +69,6 @@ class PickMatchingBalls(Environment):
             self.max_balls if not self.randomize else random.randint(3, self.max_balls)
         )
         self.balls = [Ball(color=random.randint(0, 5)) for _ in range(num_balls)]
-        self.step = 0
         return self.observe()
 
     def observe(self) -> Observation:
@@ -116,7 +114,6 @@ class PickMatchingBalls(Environment):
             },
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(self.step, reward) if done else None,
         )
 
     def act(self, actions: Mapping[ActionType, Action]) -> Observation:
@@ -125,5 +122,4 @@ class PickMatchingBalls(Environment):
         for selected_ball in action.actees:
             assert not self.balls[selected_ball].selected
             self.balls[selected_ball].selected = True
-        self.step += 1
         return self.observe()

--- a/entity_gym/entity_gym/examples/rock_paper_scissors.py
+++ b/entity_gym/entity_gym/examples/rock_paper_scissors.py
@@ -10,7 +10,6 @@ from entity_gym.environment import (
     CategoricalActionMask,
     CategoricalActionSpace,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -107,5 +106,4 @@ class RockPaperScissors(Environment):
             visible={"Opponent": [self.cheat]},
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(1, reward),
         )

--- a/entity_gym/entity_gym/examples/xor.py
+++ b/entity_gym/entity_gym/examples/xor.py
@@ -10,7 +10,6 @@ from entity_gym.environment import (
     CategoricalActionMask,
     CategoricalActionSpace,
     Environment,
-    EpisodeStats,
     Observation,
     ObsSpace,
 )
@@ -92,5 +91,4 @@ class Xor(Environment):
             ids={"Output": [0], "Bit1": [1], "Bit2": [2]},
             reward=reward,
             done=done,
-            end_of_episode_info=EpisodeStats(1, reward) if done else None,
         )

--- a/entity_gym/entity_gym/serialization/msgpack_ragged.py
+++ b/entity_gym/entity_gym/serialization/msgpack_ragged.py
@@ -18,7 +18,6 @@ WHITELIST = {
     "SelectEntityActionSpace": SelectEntityActionSpace,
     "CategoricalActionSpace": CategoricalActionSpace,
     "Entity": Entity,
-    "EpisodeStats": EpisodeStats,
 }
 
 

--- a/entity_gym/entity_gym/serialization/sample_recorder.py
+++ b/entity_gym/entity_gym/serialization/sample_recorder.py
@@ -145,11 +145,7 @@ class SampleRecordingVecEnv(VecEnv):
                     },
                     reward=self.last_obs.reward[select],
                     done=self.last_obs.done[select],
-                    end_of_episode_info={
-                        i: self.last_obs.end_of_episode_info[i]
-                        for i in indices
-                        if i in self.last_obs.end_of_episode_info
-                    },
+                    metrics=self.last_obs.metrics,
                     visible={k: v[indices] for k, v in self.last_obs.visible.items()},
                 )
                 self.sample_recorder.record(

--- a/entity_gym/entity_gym/tests/test_environment.py
+++ b/entity_gym/entity_gym/tests/test_environment.py
@@ -67,7 +67,6 @@ def test_parallel_env_list() -> None:
     }
     obs_act = envs.act(actions_xor, Xor.obs_space())
     assert len(obs_act.done) == 100
-    assert len(obs_act.end_of_episode_info) == 100
 
 
 def test_batch_obs_entities() -> None:
@@ -370,7 +369,7 @@ def test_merge_obs_entities() -> None:
         action_masks={},
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -388,7 +387,7 @@ def test_merge_obs_entities() -> None:
         action_masks={},
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -460,7 +459,7 @@ def test_merge_obs_actions_categorical() -> None:
         },
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -507,7 +506,7 @@ def test_merge_obs_actions_categorical() -> None:
         },
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -571,7 +570,7 @@ def test_merge_obs_actions_select_entity() -> None:
         },
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -610,7 +609,7 @@ def test_merge_obs_actions_select_entity() -> None:
         },
         reward=np.array([0] * 10, np.float32),
         done=np.array([False] * 10, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -657,7 +656,7 @@ def test_merge_empty_masks() -> None:
         },
         reward=np.array([0] * 3, np.float32),
         done=np.array([False] * 3, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 
@@ -679,7 +678,7 @@ def test_merge_empty_masks() -> None:
         },
         reward=np.array([0] * 3, np.float32),
         done=np.array([False] * 3, np.bool_),
-        end_of_episode_info={},
+        metrics={},
         visible={},
     )
 

--- a/entity_gym/entity_gym/tests/test_sample_recorder.py
+++ b/entity_gym/entity_gym/tests/test_sample_recorder.py
@@ -55,7 +55,7 @@ def test_serde_sample() -> None:
             },
             reward=np.array([0.3124125987123489]),
             done=np.array([False]),
-            end_of_episode_info={},
+            metrics={},
         ),
         probs={
             "move": RaggedBufferF32.from_array(


### PR DESCRIPTION
Removes `EpisodeStats` and adds a `VecEnv` wrapper that automatically collects metrics for rewards and episode lengths.

Fixes https://github.com/entity-neural-network/incubator/issues/75