### PR TITLE
Batch allreduce ops

### DIFF
--- a/enn_ppo/enn_ppo/eval.py
+++ b/enn_ppo/enn_ppo/eval.py
@@ -52,13 +52,13 @@ def run_eval(
             ] = opponent
         else:
             agents = [
-                (np.array([2 * i for i in range(num_envs // 2)]), agent),
+                (np.array([2 * i for i in range(num_envs // parallelism // 2)]), agent),
                 (
-                    np.array([2 * i + 1 for i in range(num_envs // 2)]),
+                    np.array([2 * i + 1 for i in range(num_envs // parallelism // 2)]),
                     opponent,
                 ),
             ]
-            metric_filter = np.arange(num_envs) % 2 == 0
+            metric_filter = np.arange(num_envs // parallelism) % 2 == 0
     else:
         agents = agent
 

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -555,9 +555,17 @@ def init_process(xp_info: Any, backend: str = "gloo") -> None:
 
 
 def gradient_allreduce(model: Any) -> None:
+    all_grads_list = []
     for param in model.parameters():
         if param.grad is not None:
-            dist.all_reduce(param.grad.data, op=dist.ReduceOp.SUM)
+            all_grads_list.append(param.grad.view(-1))
+    all_grads = torch.cat(all_grads_list)
+    dist.all_reduce(all_grads, op=dist.ReduceOp.SUM)
+    offset = 0
+    for param in model.parameters():
+        if param.grad is not None:
+            param.grad.data.copy_(all_grads[offset:offset + param.numel()].view_as(param.grad.data))
+            offset += param.numel()
 
 
 def _train(cfg: TrainConfig) -> float:

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -564,7 +564,9 @@ def gradient_allreduce(model: Any) -> None:
     offset = 0
     for param in model.parameters():
         if param.grad is not None:
-            param.grad.data.copy_(all_grads[offset:offset + param.numel()].view_as(param.grad.data))
+            param.grad.data.copy_(
+                all_grads[offset : offset + param.numel()].view_as(param.grad.data)
+            )
             offset += param.numel()
 
 


### PR DESCRIPTION
Perform a single allreduce operation over all parameters, which significantly reduces overhead and gives much better performance, especially with many data-parallel replicas. On basic tests I ran, performance matched torch DistributedDataParallel implementation.

Current implementation hits a nice sweet spot of simplicity and performance. There are more opportunities for speedups (smartly grouping parameters and running allreduce in parallel with backward pass), but exploiting these is much more involved and would probably require pulling in horovod or somesuch framework.