### PR TITLE
Make obs_space and action_space methods

### DIFF
--- a/enn_ppo/enn_ppo/eval.py
+++ b/enn_ppo/enn_ppo/eval.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Mapping, Optional, Tuple, Type, Union
+from typing import Callable, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/enn_ppo/enn_ppo/eval.py
+++ b/enn_ppo/enn_ppo/eval.py
@@ -19,7 +19,6 @@ def run_eval(
     cfg: EvalConfig,
     env_cfg: EnvConfig,
     rollout: RolloutConfig,
-    env_cls: Type[Environment],
     create_env: Callable[[EnvConfig, int, int, int], VecEnv],
     create_opponent: Callable[
         [str, ObsSpace, Mapping[str, ActionSpace], torch.device], PPOAgent
@@ -35,8 +34,18 @@ def run_eval(
     # TODO: metrics are biased towards short episodes
     processes = cfg.processes or rollout.processes
     num_envs = cfg.num_envs or rollout.num_envs
-    obs_space = env_cls.obs_space()
-    action_space = env_cls.action_space()
+
+    envs: VecEnv = AddMetricsWrapper(
+        create_env(
+            cfg.env or env_cfg,
+            num_envs // parallelism,
+            processes,
+            rank * num_envs // parallelism,
+        ),
+        metric_filter,
+    )
+    obs_space = envs.obs_space()
+    action_space = envs.action_space()
 
     assert num_envs % parallelism == 0, (
         "Number of eval environments must be divisible by parallelism: "
@@ -61,16 +70,6 @@ def run_eval(
             metric_filter = np.arange(num_envs // parallelism) % 2 == 0
     else:
         agents = agent
-
-    envs: VecEnv = AddMetricsWrapper(
-        create_env(
-            cfg.env or env_cfg,
-            num_envs // parallelism,
-            processes,
-            rank * num_envs // parallelism,
-        ),
-        metric_filter,
-    )
 
     if cfg.capture_samples:
         envs = SampleRecordingVecEnv(

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -1,11 +1,12 @@
 # adapted from https://github.com/vwxyzjn/cleanrl
+import inspect
 import json
 import os
 import random
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Type
+from typing import Any, Callable, Dict, Mapping, Optional, Type, Union
 
 import hyperstate
 import numpy as np
@@ -30,6 +31,9 @@ from entity_gym.simple_trace import Tracer
 from rogue_net.rogue_net import RogueNet
 
 
+EnvFactory = Callable[[EnvConfig, int, int, int], VecEnv]
+
+
 class SerializableRogueNet(RogueNet, hyperstate.Serializable[TrainConfig, "State"]):
     def serialize(self) -> Any:
         return self.state_dict()
@@ -38,11 +42,12 @@ class SerializableRogueNet(RogueNet, hyperstate.Serializable[TrainConfig, "State
     def deserialize(
         clz, state_dict: Any, config: TrainConfig, state: "State", ctx: Dict[str, Any]
     ) -> "SerializableRogueNet":
-        env_cls: Type[Environment] = ctx["env_cls"]
+        obs_space: ObsSpace = ctx["obs_space"]
+        action_space: Dict[ActionType, ActionSpace] = ctx["action_space"]
         net = SerializableRogueNet(
             config.net,
-            env_cls.obs_space(),
-            env_cls.action_space(),
+            obs_space,
+            action_space,
             regression_heads={"value": 1},
         )
         net.load_state_dict(state_dict)
@@ -109,8 +114,7 @@ class State(hyperstate.Lazy):
 
 def train(
     state_manager: StateManager[TrainConfig, State],
-    env_cls: Type[Environment],
-    create_env: Optional[Callable[[EnvConfig, int, int, int], VecEnv]] = None,
+    env: Union[Type[Environment], EnvFactory],
     create_opponent: Optional[
         Callable[[str, ObsSpace, Mapping[str, ActionSpace], torch.device], PPOAgent]
     ] = None,
@@ -185,8 +189,10 @@ def train(
     torch.manual_seed(cfg.seed)
     torch.backends.cudnn.deterministic = cfg.torch_deterministic
 
-    if create_env is None:
-        create_env = _env_factory(env_cls)
+    if inspect.isclass(env) and issubclass(env, Environment):  # type: ignore
+        create_env: EnvFactory = _env_factory(env)  # type: ignore
+    else:
+        create_env = env  # type: ignore
     envs: VecEnv = AddMetricsWrapper(
         create_env(
             cfg.env,
@@ -195,10 +201,11 @@ def train(
             rank * cfg.rollout.num_envs // parallelism,
         ),
     )
-    obs_space = env_cls.obs_space()
-    action_space = env_cls.action_space()
+    obs_space = envs.obs_space()
+    action_space = envs.action_space()
 
-    state_manager.set_deserialize_ctx("env_cls", env_cls)
+    state_manager.set_deserialize_ctx("obs_space", obs_space)
+    state_manager.set_deserialize_ctx("action_space", action_space)
     state_manager.set_deserialize_ctx("agent", agent)
     state = state_manager.state
     if state.step > 0:
@@ -274,7 +281,6 @@ def train(
                     cfg.eval,
                     cfg.env,
                     cfg.rollout,
-                    env_cls,
                     create_env,
                     create_opponent or create_random_opponent,
                     agent,
@@ -616,11 +622,13 @@ def gradient_allreduce(model: Any) -> None:
             offset += param.numel()
 
 
-def _create_agent(cfg: TrainConfig, env_cls: Type[Environment]) -> SerializableRogueNet:
+def _create_agent(
+    cfg: TrainConfig, obs_space: ObsSpace, action_space: Dict[ActionType, ActionSpace]
+) -> SerializableRogueNet:
     return SerializableRogueNet(
         cfg.net,
-        env_cls.obs_space(),
-        env_cls.action_space(),
+        obs_space,
+        action_space,
         regression_heads={"value": 1},
     )
 
@@ -637,7 +645,7 @@ def initialize(cfg: TrainConfig, ctx: Dict[str, Any]) -> State:
     if ctx.get("agent") is not None:
         agent: SerializableRogueNet = ctx["agent"]
     else:
-        agent = _create_agent(cfg, ctx["env_cls"])
+        agent = _create_agent(cfg, ctx["obs_space"], ctx["action_space"])
     optimizer = SerializableAdamW(
         agent.parameters(),
         lr=cfg.optim.lr,
@@ -647,7 +655,7 @@ def initialize(cfg: TrainConfig, ctx: Dict[str, Any]) -> State:
 
     if cfg.vf_net is not None:
         value_function: Optional[SerializableRogueNet] = _create_agent(
-            cfg, ctx["env_cls"]
+            cfg, ctx["obs_space"], ctx["action_space"]
         )
         vf_optimizer: Optional[SerializableAdamW] = SerializableAdamW(
             value_function.parameters(),  # type: ignore

--- a/enn_ppo/enn_ppo/train.py
+++ b/enn_ppo/enn_ppo/train.py
@@ -30,7 +30,6 @@ from entity_gym.serialization import SampleRecordingVecEnv
 from entity_gym.simple_trace import Tracer
 from rogue_net.rogue_net import RogueNet
 
-
 EnvFactory = Callable[[EnvConfig, int, int, int], VecEnv]
 
 

--- a/enn_zoo/enn_zoo/codecraft/cc_vec_env.py
+++ b/enn_zoo/enn_zoo/codecraft/cc_vec_env.py
@@ -1,10 +1,9 @@
 import math
 import time
-from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -12,13 +11,11 @@ from ragged_buffer import RaggedBufferBool, RaggedBufferF32, RaggedBufferI64
 
 from enn_zoo.codecraft import rest_client
 from enn_zoo.codecraft.rest_client import ObsConfig, Rules
-from entity_gym.environment import Environment, ObsSpace, VecEnv
+from entity_gym.environment import ObsSpace, VecEnv
 from entity_gym.environment.environment import (
-    Action,
     ActionSpace,
     CategoricalActionSpace,
     Entity,
-    Observation,
 )
 from entity_gym.environment.vec_env import Metric, VecCategoricalActionMask, VecObs
 

--- a/enn_zoo/enn_zoo/codecraft/cc_vec_env.py
+++ b/enn_zoo/enn_zoo/codecraft/cc_vec_env.py
@@ -30,7 +30,7 @@ from .maps import (
     map_enhanced,
 )
 
-LAST_OBS = {}
+LAST_OBS: Any = {}
 VERIFY = False
 
 DRONE_FEATS = [
@@ -197,127 +197,6 @@ class Objective(Enum):
             ]
         else:
             return []
-
-
-def codecraft_env_class(
-    objective: Union[Objective, str], hidden_obs: bool
-) -> Type[Environment]:
-    if isinstance(objective, str):
-        objective = Objective(objective)
-
-    extra_build_actions = [
-        "build_"
-        + "".join(
-            [
-                f"{count}{letter}"
-                for count, letter in zip(build, ["s", "m", "c", "e", "p", "l"])
-                if count > 0
-            ]
-        )
-        for build in objective.extra_builds()
-    ]
-    extra_drone_features = [
-        "constructing_"
-        + "".join(
-            [
-                f"{count}{letter}"
-                for count, letter in zip(build, ["s", "m", "c", "e", "p", "l"])
-                if count > 0
-            ]
-        )
-        for build in objective.extra_builds()
-    ]
-    extra_global_features = [
-        "cost_multiplier_"
-        + "".join(
-            [
-                f"{count}{letter}"
-                for count, letter in zip(build, ["s", "m", "c", "e", "p", "l"])
-                if count > 0
-            ]
-        )
-        for build in objective.extra_builds()
-    ]
-    if objective == Objective.ARENA_MEDIUM or objective == objective.ARENA_TINY_2V2:
-        drone_features = list(MIN_DRONE_FEATS) + extra_drone_features
-        global_features = list(MIN_GLOBAL_FEATS)
-        mineral_features = ["x", "y", "size"]
-    else:
-        drone_features = list(DRONE_FEATS) + extra_drone_features
-        global_features = list(GLOBAL_FEATS)
-        mineral_features = ["x", "y", "size", "claimed"]
-    global_features[-1:-1] = extra_global_features
-
-    class CodeCraftEnv(Environment):
-        @classmethod
-        def obs_space(cls) -> ObsSpace:
-            return ObsSpace(
-                entities={
-                    "ally": Entity(drone_features + global_features),
-                    "enemy": Entity(drone_features),
-                    "all_enemy": Entity(drone_features),
-                    "mineral": Entity(mineral_features),
-                    "tile": Entity(
-                        [
-                            "x",
-                            "y",
-                            "last_visited_time",
-                            "visited",
-                        ]
-                    ),
-                }
-            )
-
-        @classmethod
-        def action_space(cls) -> Dict[str, ActionSpace]:
-            return {
-                # 0-5: turn/movement (4 is no turn, no movement)
-                # 6: build [0,1,0,0,0] drone (if minerals > 5)
-                # 7: deposit resources
-                "act": CategoricalActionSpace(
-                    [
-                        "move_left",
-                        "move_forward",
-                        "move_right",
-                        "turn_left",
-                        "halt",
-                        "turn_right",
-                        "build_1m",
-                        "deposit_resources",
-                        # feat_lock_build_action
-                        # "unlock_build_action",
-                        # "lock_build_action",
-                    ]
-                    + extra_build_actions
-                )
-            }
-
-        def reset(self) -> Observation:
-            raise NotImplementedError
-
-        def act(self, action: Mapping[str, Action]) -> Observation:
-            raise NotImplementedError
-
-        def close(self) -> None:
-            pass
-
-        def env_cls(self) -> Type["Environment"]:
-            return self.__class__
-
-        @classmethod
-        @abstractmethod
-        def objective(cls) -> Objective:
-            pass
-
-        @classmethod
-        @abstractmethod
-        def extra_build_actions(cls) -> List[str]:
-            pass
-
-        def hidden_obs(self) -> bool:
-            return hidden_obs
-
-    return CodeCraftEnv
 
 
 @dataclass
@@ -1003,8 +882,98 @@ class CodeCraftVecEnv(VecEnv):
     def __len__(self) -> int:
         return self.num_envs
 
-    def env_cls(self) -> Type[Environment]:
-        return codecraft_env_class(self.objective, self.hidden_obs)
+    def _features(self) -> Tuple[List[str], List[str], List[str]]:
+        objective = self.objective
+        if isinstance(objective, str):
+            objective = Objective(objective)
+
+        extra_drone_features = [
+            "constructing_"
+            + "".join(
+                [
+                    f"{count}{letter}"
+                    for count, letter in zip(build, ["s", "m", "c", "e", "p", "l"])
+                    if count > 0
+                ]
+            )
+            for build in objective.extra_builds()
+        ]
+        extra_global_features = [
+            "cost_multiplier_"
+            + "".join(
+                [
+                    f"{count}{letter}"
+                    for count, letter in zip(build, ["s", "m", "c", "e", "p", "l"])
+                    if count > 0
+                ]
+            )
+            for build in objective.extra_builds()
+        ]
+        if objective == Objective.ARENA_MEDIUM or objective == objective.ARENA_TINY_2V2:
+            drone_features = list(MIN_DRONE_FEATS) + extra_drone_features
+            global_features = list(MIN_GLOBAL_FEATS)
+            mineral_features = ["x", "y", "size"]
+        else:
+            drone_features = list(DRONE_FEATS) + extra_drone_features
+            global_features = list(GLOBAL_FEATS)
+            mineral_features = ["x", "y", "size", "claimed"]
+        global_features[-1:-1] = extra_global_features
+        return global_features, drone_features, mineral_features
+
+    def _extra_build_actions(self) -> List[str]:
+        return [
+            "build_"
+            + "".join(
+                [
+                    f"{count}{letter}"
+                    for count, letter in zip(build, ["s", "m", "c", "e", "p", "l"])
+                    if count > 0
+                ]
+            )
+            for build in self.objective.extra_builds()
+        ]
+
+    def obs_space(self) -> ObsSpace:
+        global_features, drone_features, mineral_features = self._features()
+        return ObsSpace(
+            entities={
+                "ally": Entity(drone_features + global_features),
+                "enemy": Entity(drone_features),
+                "all_enemy": Entity(drone_features),
+                "mineral": Entity(mineral_features),
+                "tile": Entity(
+                    [
+                        "x",
+                        "y",
+                        "last_visited_time",
+                        "visited",
+                    ]
+                ),
+            }
+        )
+
+    def action_space(self) -> Dict[str, ActionSpace]:
+        return {
+            # 0-5: turn/movement (4 is no turn, no movement)
+            # 6: build [0,1,0,0,0] drone (if minerals > 5)
+            # 7: deposit resources
+            "act": CategoricalActionSpace(
+                [
+                    "move_left",
+                    "move_forward",
+                    "move_right",
+                    "turn_left",
+                    "halt",
+                    "turn_right",
+                    "build_1m",
+                    "deposit_resources",
+                    # feat_lock_build_action
+                    # "unlock_build_action",
+                    # "lock_build_action",
+                ]
+                + self._extra_build_actions()
+            )
+        }
 
 
 def dist(x1: float, y1: float, x2: float, y2: float) -> float:

--- a/enn_zoo/enn_zoo/codecraft/codecraftnet/codecraftnet.py
+++ b/enn_zoo/enn_zoo/codecraft/codecraftnet/codecraftnet.py
@@ -782,7 +782,7 @@ class ItemBlock(nn.Module):
         return x
 
 
-ARANGE_CACHED = None
+ARANGE_CACHED: Optional[torch.Tensor] = None
 ARANGE_MAX = 0
 
 

--- a/enn_zoo/enn_zoo/microrts/__init__.py
+++ b/enn_zoo/enn_zoo/microrts/__init__.py
@@ -123,8 +123,7 @@ class GymMicrorts(Environment):
         # get the unit type table
         self.utt = json.loads(str(self.client.sendUTT()))
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return ObsSpace(
             {
                 "Resource": Entity(["x", "y"]),
@@ -137,8 +136,7 @@ class GymMicrorts(Environment):
             }
         )
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {
             "unit_action": CategoricalActionSpace(
                 choices=[

--- a/enn_zoo/enn_zoo/microrts/main.py
+++ b/enn_zoo/enn_zoo/microrts/main.py
@@ -25,8 +25,8 @@ if __name__ == "__main__":
 
     print(env_cls)
     env = env_cls()
-    obs_space = env_cls.obs_space()
-    actions = env_cls.action_space()
+    obs_space = env.obs_space()
+    actions = env.action_space()
     obs = env.reset_filter(obs_space)
     total_reward = obs.reward
     while not obs.done:

--- a/enn_zoo/enn_zoo/procgen_env/base_env.py
+++ b/enn_zoo/enn_zoo/procgen_env/base_env.py
@@ -53,35 +53,30 @@ class BaseEnv(Environment):
             distribution_mode=distribution_mode,
         )
 
-    @classmethod
     @abstractmethod
-    def _global_feats(cls) -> List[str]:
+    def _global_feats(self) -> List[str]:
         pass
 
-    @classmethod
     @abstractmethod
-    def deserialize_global_feats(cls, data: ByteBuffer) -> List[float]:
+    def deserialize_global_feats(self, data: ByteBuffer) -> List[float]:
         pass
 
-    @classmethod
     @abstractmethod
-    def _entity_types(cls) -> Dict[int, str]:
+    def _entity_types(self) -> Dict[int, str]:
         pass
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return ObsSpace(
             {
-                "Player": Entity(features=ENTITY_FEATS + cls._global_feats()),
+                "Player": Entity(features=ENTITY_FEATS + self._global_feats()),
                 **{
-                    entity_type: Entity(features=ENTITY_FEATS + cls._global_feats())
-                    for entity_type in cls._entity_types().values()
+                    entity_type: Entity(features=ENTITY_FEATS + self._global_feats())
+                    for entity_type in self._entity_types().values()
                 },
             }
         )
 
-    @classmethod
-    def action_space(cls) -> Dict[ActionType, ActionSpace]:
+    def action_space(self) -> Dict[ActionType, ActionSpace]:
         return {
             "act": CategoricalActionSpace(
                 [
@@ -113,7 +108,7 @@ class BaseEnv(Environment):
         state = MinimalProcgenState.from_bytes(data)
 
         global_feats = np.array(
-            self.__class__.deserialize_global_feats(data), dtype=np.float32
+            self.deserialize_global_feats(data), dtype=np.float32
         ).reshape(1, -1)
         entities = {
             "Player": EntityObs(

--- a/enn_zoo/enn_zoo/procgen_env/big_fish.py
+++ b/enn_zoo/enn_zoo/procgen_env/big_fish.py
@@ -10,14 +10,11 @@ class BigFish(BaseEnv):
     def __init__(self, distribution_mode: str = "hard") -> None:
         super().__init__("bigfish", distribution_mode)
 
-    @classmethod
-    def _global_feats(cls) -> List[str]:
+    def _global_feats(self) -> List[str]:
         return BIG_FISH_FEATS
 
-    @classmethod
-    def deserialize_global_feats(cls, data: ByteBuffer) -> List[float]:
+    def deserialize_global_feats(self, data: ByteBuffer) -> List[float]:
         return [float(data.read_int()), data.read_float()]
 
-    @classmethod
-    def _entity_types(cls) -> Dict[int, str]:
+    def _entity_types(self) -> Dict[int, str]:
         return {2: "Fish"}

--- a/enn_zoo/enn_zoo/procgen_env/boss_fight.py
+++ b/enn_zoo/enn_zoo/procgen_env/boss_fight.py
@@ -60,12 +60,10 @@ class BossFight(BaseEnv):
     def __init__(self, distribution_mode: str = "hard") -> None:
         super().__init__("bossfight", distribution_mode)
 
-    @classmethod
-    def _global_feats(cls) -> List[str]:
+    def _global_feats(self) -> List[str]:
         return BOSS_FIGHT_FEATS
 
-    @classmethod
-    def deserialize_global_feats(cls, data: ByteBuffer) -> List[float]:
+    def deserialize_global_feats(self, data: ByteBuffer) -> List[float]:
         # Skip attack modes
         data.read_array(elem_size=4)
         feats = [
@@ -96,8 +94,7 @@ class BossFight(BaseEnv):
         # assert len(data.data) == data.offset
         return feats
 
-    @classmethod
-    def _entity_types(cls) -> Dict[int, str]:
+    def _entity_types(self) -> Dict[int, str]:
         return {
             1: "PlayerBullet",
             2: "Boss",

--- a/enn_zoo/enn_zoo/procgen_env/leaper.py
+++ b/enn_zoo/enn_zoo/procgen_env/leaper.py
@@ -32,12 +32,10 @@ class Leaper(BaseEnv):
     def __init__(self, distribution_mode: str = "hard") -> None:
         super().__init__("leaper", distribution_mode)
 
-    @classmethod
-    def _global_feats(cls) -> List[str]:
+    def _global_feats(self) -> List[str]:
         return LEAPER_FEATS
 
-    @classmethod
-    def deserialize_global_feats(cls, data: ByteBuffer) -> List[float]:
+    def deserialize_global_feats(self, data: ByteBuffer) -> List[float]:
         bottom_road_y = float(data.read_int())
         road_lane_speeds = data.read_float_array()
         bottom_water_y = float(data.read_int())
@@ -65,8 +63,7 @@ class Leaper(BaseEnv):
             goal_y,
         ]
 
-    @classmethod
-    def _entity_types(cls) -> Dict[int, str]:
+    def _entity_types(self) -> Dict[int, str]:
         # const int LOG = 1;
         # const int ROAD = 2;
         # const int WATER = 3;

--- a/enn_zoo/enn_zoo/procgen_env/plunder.py
+++ b/enn_zoo/enn_zoo/procgen_env/plunder.py
@@ -52,12 +52,10 @@ class Plunder(BaseEnv):
     def __init__(self, distribution_mode: str = "hard") -> None:
         super().__init__("plunder", distribution_mode)
 
-    @classmethod
-    def _global_feats(cls) -> List[str]:
+    def _global_feats(self) -> List[str]:
         return PLUNDER_FEATS
 
-    @classmethod
-    def deserialize_global_feats(cls, data: ByteBuffer) -> List[float]:
+    def deserialize_global_feats(self, data: ByteBuffer) -> List[float]:
         last_fire_time = float(data.read_int())
         lane_directions = data.read_int_array()
         target_bools = data.read_int_array()
@@ -91,8 +89,7 @@ class Plunder(BaseEnv):
             min_agent_x,
         ]
 
-    @classmethod
-    def _entity_types(cls) -> Dict[int, str]:
+    def _entity_types(self) -> Dict[int, str]:
         return {
             1: "PlayerBullet",
             2: "TargetLegend",

--- a/enn_zoo/enn_zoo/procgen_env/star_pilot.py
+++ b/enn_zoo/enn_zoo/procgen_env/star_pilot.py
@@ -8,16 +8,13 @@ class StarPilot(BaseEnv):
     def __init__(self, distribution_mode: str = "hard") -> None:
         super().__init__("starpilot", distribution_mode)
 
-    @classmethod
-    def _global_feats(cls) -> List[str]:
+    def _global_feats(self) -> List[str]:
         return []
 
-    @classmethod
-    def deserialize_global_feats(cls, data: ByteBuffer) -> List[float]:
+    def deserialize_global_feats(self, data: ByteBuffer) -> List[float]:
         return []
 
-    @classmethod
-    def _entity_types(cls) -> Dict[int, str]:
+    def _entity_types(self) -> Dict[int, str]:
         return {
             1: "BulletPlayer",
             2: "Bullet2",

--- a/enn_zoo/enn_zoo/train.py
+++ b/enn_zoo/enn_zoo/train.py
@@ -2,7 +2,6 @@ import json
 from contextlib import ExitStack
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional, Type, Union
-from enn_zoo.codecraft import cc_vec_env
 
 import hyperstate
 import torch

--- a/enn_zoo/enn_zoo/train.py
+++ b/enn_zoo/enn_zoo/train.py
@@ -1,7 +1,8 @@
 import json
 from contextlib import ExitStack
 from dataclasses import dataclass
-from typing import Mapping, Optional
+from typing import Callable, Mapping, Optional, Type, Union
+from enn_zoo.codecraft import cc_vec_env
 
 import hyperstate
 import torch
@@ -12,7 +13,7 @@ import enn_ppo.config as config
 from enn_ppo.agent import PPOAgent
 from enn_ppo.train import State, initialize, train
 from enn_zoo import griddly_env
-from enn_zoo.codecraft.cc_vec_env import CodeCraftVecEnv, codecraft_env_class
+from enn_zoo.codecraft.cc_vec_env import CodeCraftVecEnv
 from enn_zoo.codecraft.codecraftnet.adapter import CCNetAdapter
 from enn_zoo.griddly_env import GRIDDLY_ENVS
 from enn_zoo.microrts import GymMicrorts
@@ -69,26 +70,26 @@ def load_codecraft_policy(
 def main(state_manager: StateManager) -> None:
     cfg = state_manager.config
     if cfg.env.id in ENV_REGISTRY:
-        env_cls = ENV_REGISTRY[cfg.env.id]
+        env: Union[
+            Type[Environment], Callable[[config.EnvConfig, int, int, int], VecEnv]
+        ] = ENV_REGISTRY[cfg.env.id]
     elif cfg.env.id in GRIDDLY_ENVS:
-        env_cls = griddly_env.create_env(**GRIDDLY_ENVS[cfg.env.id])
+        env = griddly_env.create_env(**GRIDDLY_ENVS[cfg.env.id])
     elif cfg.env.id == "CodeCraft":
-        objective = json.loads(cfg.env.kwargs).get("objective", "ALLIED_WEALTH")
-        hidden_obs = json.loads(cfg.env.kwargs).get("hidden_obs", False)
-        env_cls = codecraft_env_class(objective, hidden_obs)
+        env = create_cc_env
     elif cfg.env.id == "GymMicrorts":
-        env_cls = GymMicrorts
+        env = GymMicrorts
     elif cfg.env.id.startswith("Procgen"):
         if cfg.env.id == "Procgen:BigFish":
-            env_cls = BigFish
+            env = BigFish
         elif cfg.env.id == "Procgen:BossFight":
-            env_cls = BossFight
+            env = BossFight
         elif cfg.env.id == "Procgen:StarPilot":
-            env_cls = StarPilot
+            env = StarPilot
         elif cfg.env.id == "Procgen:Leaper":
-            env_cls = Leaper
+            env = Leaper
         elif cfg.env.id == "Procgen:Plunder":
-            env_cls = Plunder
+            env = Plunder
         else:
             raise NotImplementedError(f"Unknown procgen env: {cfg.env.id}")
     else:
@@ -96,7 +97,7 @@ def main(state_manager: StateManager) -> None:
             from enn_zoo import vizdoom_env
             from enn_zoo.vizdoom_env import VIZDOOM_ENVS
 
-            env_cls = vizdoom_env.create_vizdoom_env(VIZDOOM_ENVS[cfg.env.id])
+            env = vizdoom_env.create_vizdoom_env(VIZDOOM_ENVS[cfg.env.id])
         except ImportError:
             raise KeyError(
                 f"Unknown gym_id: {cfg.env.id}\nAvailable environments: {list(ENV_REGISTRY.keys()) + list(GRIDDLY_ENVS.keys()) + ['CodeCraft']}"
@@ -111,9 +112,8 @@ def main(state_manager: StateManager) -> None:
             stack.enter_context(web_pdb.catch_post_mortem())
         train(
             state_manager=state_manager,
-            env_cls=env_cls,
+            env=env,
             agent=agent,
-            create_env=create_cc_env if cfg.env.id == "CodeCraft" else None,
             create_opponent=load_codecraft_policy
             if cfg.env.id == "CodeCraft"
             else None,

--- a/enn_zoo/enn_zoo/vizdoom_env/__init__.py
+++ b/enn_zoo/enn_zoo/vizdoom_env/__init__.py
@@ -1,8 +1,7 @@
 import os
-from typing import Dict, Type
+from typing import Type
 
 from enn_zoo.vizdoom_env.vizdoom_environment import DoomEntityEnvironment
-from entity_gym.environment import ActionSpace, ObsSpace
 
 init_path = os.path.dirname(os.path.realpath(__file__))
 VIZDOOM_ENVS = {

--- a/enn_zoo/enn_zoo/vizdoom_env/__init__.py
+++ b/enn_zoo/enn_zoo/vizdoom_env/__init__.py
@@ -24,20 +24,8 @@ def create_vizdoom_env(
     Copied from the Griddly code.
     """
 
-    env = DoomEntityEnvironment(config_file_path)
-    observation_space = env._observation_space
-    action_space = env._action_space
-
     class InstantiatedDoomEntityEnvironment(DoomEntityEnvironment):
         def __init__(self, frame_skip: int = 4):
             super().__init__(config_file_path, frame_skip)
-
-        @classmethod
-        def obs_space(cls) -> ObsSpace:
-            return observation_space
-
-        @classmethod
-        def action_space(cls) -> Dict[str, ActionSpace]:
-            return action_space
 
     return InstantiatedDoomEntityEnvironment

--- a/enn_zoo/enn_zoo/vizdoom_env/vizdoom_environment.py
+++ b/enn_zoo/enn_zoo/vizdoom_env/vizdoom_environment.py
@@ -158,12 +158,10 @@ class DoomEntityEnvironment(Environment):
                 self._action_space[action] = CategoricalActionSpace(["off", "on"])
             self._action_mask[action] = CategoricalActionMask(actor_ids=[0], mask=None)
 
-    def obs_space(self) -> ObsSpace:  # type: ignore
+    def obs_space(self) -> ObsSpace:
         return self._observation_space
 
-    def action_space(  # type: ignore
-        self,
-    ) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return self._action_space
 
     def _build_state(self, state: Any, reward: float, terminal: bool) -> Observation:

--- a/entity_gym/entity_gym/environment/add_metrics_wrapper.py
+++ b/entity_gym/entity_gym/environment/add_metrics_wrapper.py
@@ -1,15 +1,10 @@
-from typing import Any, Dict, Mapping, Optional, Type
+from typing import Any, Dict, Mapping, Optional
 
 import numpy as np
 import numpy.typing as npt
 from ragged_buffer import RaggedBufferI64
 
-from entity_gym.environment.environment import (
-    ActionSpace,
-    ActionType,
-    Environment,
-    ObsSpace,
-)
+from entity_gym.environment.environment import ActionSpace, ActionType, ObsSpace
 from entity_gym.environment.vec_env import Metric, VecEnv, VecObs
 
 

--- a/entity_gym/entity_gym/environment/add_metrics_wrapper.py
+++ b/entity_gym/entity_gym/environment/add_metrics_wrapper.py
@@ -1,10 +1,15 @@
-from typing import Any, Mapping, Optional, Type
+from typing import Any, Dict, Mapping, Optional, Type
 
 import numpy as np
 import numpy.typing as npt
 from ragged_buffer import RaggedBufferI64
 
-from entity_gym.environment.environment import ActionType, Environment, ObsSpace
+from entity_gym.environment.environment import (
+    ActionSpace,
+    ActionType,
+    Environment,
+    ObsSpace,
+)
 from entity_gym.environment.vec_env import Metric, VecEnv, VecObs
 
 
@@ -25,9 +30,6 @@ class AddMetricsWrapper(VecEnv):
         self.total_reward = np.zeros(len(env), dtype=np.float32)
         self.total_steps = np.zeros(len(env), dtype=np.int64)
         self.filter = np.ones(len(env), dtype=np.bool8) if filter is None else filter
-
-    def env_cls(self) -> Type[Environment]:
-        return self.env.env_cls()
 
     def reset(self, obs_config: ObsSpace) -> VecObs:
         return self.track_metrics(self.env.reset(obs_config))
@@ -71,3 +73,9 @@ class AddMetricsWrapper(VecEnv):
             max=obs.reward.max(),
         )
         return obs
+
+    def action_space(self) -> Dict[ActionType, ActionSpace]:
+        return self.env.action_space()
+
+    def obs_space(self) -> ObsSpace:
+        return self.env.obs_space()

--- a/entity_gym/entity_gym/environment/environment.py
+++ b/entity_gym/entity_gym/environment/environment.py
@@ -290,17 +290,15 @@ class Environment(ABC):
     Abstraction over reinforcement learning environments with observations based on structured lists of entities.
     """
 
-    @classmethod
     @abstractmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         """
         Returns a dictionary mapping the name of observable entities to their type.
         """
         raise NotImplementedError
 
-    @classmethod
     @abstractmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         """
         Returns a dictionary mapping the name of actions to their action space.
         """
@@ -324,7 +322,7 @@ class Environment(ABC):
         raise NotImplementedError
 
     def reset_filter(self, obs_filter: ObsSpace) -> Observation:
-        return self.__class__.filter_obs(self.reset(), obs_filter)
+        return self.filter_obs(self.reset(), obs_filter)
 
     def render(self, **kwargs: Any) -> npt.NDArray[np.uint8]:
         """
@@ -338,14 +336,13 @@ class Environment(ABC):
     def act_filter(
         self, action: Mapping[ActionType, Action], obs_filter: ObsSpace
     ) -> Observation:
-        return self.__class__.filter_obs(self.act(action), obs_filter)
+        return self.filter_obs(self.act(action), obs_filter)
 
     def close(self) -> None:
         pass
 
-    @classmethod
-    def filter_obs(cls, obs: Observation, obs_filter: ObsSpace) -> Observation:
-        selectors = cls._compile_feature_filter(obs_filter)
+    def filter_obs(self, obs: Observation, obs_filter: ObsSpace) -> Observation:
+        selectors = self._compile_feature_filter(obs_filter)
         features: Dict[
             EntityType, Union[npt.NDArray[np.float32], Sequence[Sequence[float]]]
         ] = {}
@@ -366,9 +363,8 @@ class Environment(ABC):
             metrics=obs.metrics,
         )
 
-    @classmethod
-    def _compile_feature_filter(cls, obs_space: ObsSpace) -> Dict[str, np.ndarray]:
-        obs_space = cls.obs_space()
+    def _compile_feature_filter(self, obs_space: ObsSpace) -> Dict[str, np.ndarray]:
+        obs_space = self.obs_space()
         feature_selection = {}
         for entity_name, entity in obs_space.entities.items():
             feature_selection[entity_name] = np.array(

--- a/entity_gym/entity_gym/environment/vec_env.py
+++ b/entity_gym/entity_gym/environment/vec_env.py
@@ -210,9 +210,16 @@ class VecEnv(ABC):
     """
 
     @abstractmethod
-    def env_cls(self) -> Type[Environment]:
+    def obs_space(self) -> ObsSpace:
         """
-        Returns the class of the underlying environment.
+        Returns a dictionary mapping the name of observable entities to their type.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def action_space(self) -> Dict[ActionType, ActionSpace]:
+        """
+        Returns a dictionary mapping the name of actions to their action space.
         """
         raise NotImplementedError
 

--- a/entity_gym/entity_gym/environment/vec_env.py
+++ b/entity_gym/entity_gym/environment/vec_env.py
@@ -1,7 +1,7 @@
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Type, Union, overload
+from typing import Any, Dict, List, Mapping, Optional, Union, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -12,7 +12,6 @@ from entity_gym.environment.environment import (
     ActionType,
     CategoricalActionSpace,
     EntityType,
-    Environment,
     Observation,
     ObsSpace,
     SelectEntityActionSpace,

--- a/entity_gym/entity_gym/examples/cherry_pick.py
+++ b/entity_gym/entity_gym/examples/cherry_pick.py
@@ -33,8 +33,7 @@ class CherryPick(Environment):
     last_reward: float = 0.0
     step: int = 0
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return ObsSpace(
             {
                 "Cherry": Entity(["quality"]),
@@ -42,8 +41,7 @@ class CherryPick(Environment):
             }
         )
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {"Pick Cherry": SelectEntityActionSpace()}
 
     def reset(self) -> Observation:

--- a/entity_gym/entity_gym/examples/count.py
+++ b/entity_gym/entity_gym/examples/count.py
@@ -44,12 +44,10 @@ class Count(Environment):
         ), "masked_choices must be between 1 and 10"
         self.masked_choices = masked_choices
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return obs_space_from_dataclasses(Player, Bean)
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {
             "count": CategoricalActionSpace(
                 ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
@@ -69,7 +67,7 @@ class Count(Environment):
         return self.observe(obs_space, mask)
 
     def reset(self) -> Observation:
-        return self.reset_filter(Count.obs_space())
+        return self.reset_filter(self.obs_space())
 
     def act_filter(
         self, action: Mapping[str, Action], obs_filter: ObsSpace
@@ -87,7 +85,7 @@ class Count(Environment):
     def act(self, action: Mapping[str, Action]) -> Observation:
         return self.act_filter(
             action,
-            Count.obs_space(),
+            self.obs_space(),
         )
 
     def observe(

--- a/entity_gym/entity_gym/examples/floor_is_lava.py
+++ b/entity_gym/entity_gym/examples/floor_is_lava.py
@@ -40,12 +40,10 @@ class FloorIsLava(Environment):
     The player receives a reward of 1 if they move to the high ground, and 0 otherwise.
     """
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return obs_space_from_dataclasses(Lava, HighGround, Player)
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {
             "move": CategoricalActionSpace(["n", "ne", "e", "se", "s", "sw", "w", "nw"])
         }
@@ -71,7 +69,7 @@ class FloorIsLava(Environment):
         return obs
 
     def reset(self) -> Observation:
-        return self.reset_filter(FloorIsLava.obs_space())
+        return self.reset_filter(self.obs_space())
 
     def act_filter(
         self, action: Mapping[str, Action], obs_filter: ObsSpace
@@ -96,7 +94,7 @@ class FloorIsLava(Environment):
     def act(self, action: Mapping[str, Action]) -> Observation:
         return self.act_filter(
             action,
-            FloorIsLava.obs_space(),
+            self.obs_space(),
         )
 
     def observe(self, obs_filter: ObsSpace, done: bool = False) -> Observation:

--- a/entity_gym/entity_gym/examples/minefield.py
+++ b/entity_gym/entity_gym/examples/minefield.py
@@ -53,12 +53,10 @@ class Minefield(Environment):
     translate: bool = False
     width: float = 200.0
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return obs_space_from_dataclasses(Vehicle, Mine, Target)
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {
             "move": CategoricalActionSpace(
                 ["turn left", "move forward", "turn right"],
@@ -91,7 +89,7 @@ class Minefield(Environment):
         return self.observe(obs_space)
 
     def reset(self) -> Observation:
-        return self.reset_filter(Minefield.obs_space())
+        return self.reset_filter(self.obs_space())
 
     def act_filter(
         self, action: Mapping[str, Action], obs_filter: ObsSpace
@@ -123,7 +121,7 @@ class Minefield(Environment):
     def act(self, action: Mapping[str, Action]) -> Observation:
         return self.act_filter(
             action,
-            Minefield.obs_space(),
+            self.obs_space(),
         )
 
     def observe(self, obs_filter: ObsSpace, done: bool = False) -> Observation:

--- a/entity_gym/entity_gym/examples/minesweeper.py
+++ b/entity_gym/entity_gym/examples/minesweeper.py
@@ -34,7 +34,6 @@ class MineSweeper(Environment):
         self.robots: List[Tuple[int, int]] = []
         self.mines: List[Tuple[int, int]] = []
 
-    @classmethod
     def obs_space(cls) -> ObsSpace:
         return ObsSpace(
             {
@@ -44,7 +43,6 @@ class MineSweeper(Environment):
             }
         )
 
-    @classmethod
     def action_space(cls) -> Dict[ActionType, ActionSpace]:
         return {
             "Move": CategoricalActionSpace(

--- a/entity_gym/entity_gym/examples/move_to_origin.py
+++ b/entity_gym/entity_gym/examples/move_to_origin.py
@@ -32,7 +32,6 @@ class MoveToOrigin(Environment):
     last_y_pos = 0.0
     step: int = 0
 
-    @classmethod
     def obs_space(cls) -> ObsSpace:
         return ObsSpace(
             {
@@ -42,7 +41,6 @@ class MoveToOrigin(Environment):
             }
         )
 
-    @classmethod
     def action_space(cls) -> Dict[str, ActionSpace]:
         return {
             "horizontal_thruster": CategoricalActionSpace(

--- a/entity_gym/entity_gym/examples/multi_armed_bandit.py
+++ b/entity_gym/entity_gym/examples/multi_armed_bandit.py
@@ -22,7 +22,6 @@ class MultiArmedBandit(Environment):
     Task with single cateorical action with 5 choices which gives a reward of 1 for choosing action 0 and reward of 0 otherwise.
     """
 
-    @classmethod
     def obs_space(cls) -> ObsSpace:
         return ObsSpace(
             {
@@ -30,7 +29,6 @@ class MultiArmedBandit(Environment):
             }
         )
 
-    @classmethod
     def action_space(cls) -> Dict[str, ActionSpace]:
         return {
             "pull": CategoricalActionSpace(["A", "B", "C", "D", "E"]),

--- a/entity_gym/entity_gym/examples/multi_snake.py
+++ b/entity_gym/entity_gym/examples/multi_snake.py
@@ -67,7 +67,6 @@ class MultiSnake(Environment):
         self.step = 0
         self.max_steps = max_steps
 
-    @classmethod
     def obs_space(cls) -> ObsSpace:
         return ObsSpace(
             {
@@ -77,7 +76,6 @@ class MultiSnake(Environment):
             }
         )
 
-    @classmethod
     def action_space(cls) -> Dict[str, ActionSpace]:
         return {
             "move": CategoricalActionSpace(

--- a/entity_gym/entity_gym/examples/not_hotdog.py
+++ b/entity_gym/entity_gym/examples/not_hotdog.py
@@ -24,8 +24,7 @@ class NotHotdog(Environment):
     The "Player" entity is always present, and has an action to classify the other entity as hotdog or not hotdog.
     """
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return ObsSpace(
             {
                 "Player": Entity(["step"]),
@@ -34,8 +33,7 @@ class NotHotdog(Environment):
             }
         )
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {
             "classify": CategoricalActionSpace(["hotdog", "not_hotdog"]),
             "unused_action": CategoricalActionSpace(["0", "1"]),

--- a/entity_gym/entity_gym/examples/pick_matching_balls.py
+++ b/entity_gym/entity_gym/examples/pick_matching_balls.py
@@ -40,8 +40,7 @@ class PickMatchingBalls(Environment):
         False  # randomize the number of balls to be between 3 and max_balls
     )
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return ObsSpace(
             {
                 "Ball": Entity(
@@ -60,8 +59,7 @@ class PickMatchingBalls(Environment):
             }
         )
 
-    @classmethod
-    def action_space(cls) -> Dict[ActionType, ActionSpace]:
+    def action_space(self) -> Dict[ActionType, ActionSpace]:
         return {"Pick Ball": SelectEntityActionSpace()}
 
     def reset(self) -> Observation:

--- a/entity_gym/entity_gym/examples/rock_paper_scissors.py
+++ b/entity_gym/entity_gym/examples/rock_paper_scissors.py
@@ -46,12 +46,10 @@ class RockPaperScissors(Environment):
         self.cheat = cheat
         self.reset()
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return obs_space_from_dataclasses(Player, Opponent)
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {"throw": CategoricalActionSpace(["rock", "paper", "scissors"])}
 
     def reset_filter(self, obs_space: ObsSpace) -> Observation:
@@ -65,7 +63,7 @@ class RockPaperScissors(Environment):
         return self.observe(obs_space)
 
     def reset(self) -> Observation:
-        return self.reset_filter(RockPaperScissors.obs_space())
+        return self.reset_filter(self.obs_space())
 
     def act_filter(
         self, action: Mapping[str, Action], obs_filter: ObsSpace
@@ -85,7 +83,7 @@ class RockPaperScissors(Environment):
     def act(self, action: Mapping[str, Action]) -> Observation:
         return self.act_filter(
             action,
-            RockPaperScissors.obs_space(),
+            self.obs_space(),
         )
 
     def observe(

--- a/entity_gym/entity_gym/examples/xor.py
+++ b/entity_gym/entity_gym/examples/xor.py
@@ -37,12 +37,10 @@ class Xor(Environment):
     The Output entity has one action that should be set to the output of the XOR between the two bits.
     """
 
-    @classmethod
-    def obs_space(cls) -> ObsSpace:
+    def obs_space(self) -> ObsSpace:
         return obs_space_from_dataclasses(Output, Bit1, Bit2)
 
-    @classmethod
-    def action_space(cls) -> Dict[str, ActionSpace]:
+    def action_space(self) -> Dict[str, ActionSpace]:
         return {"output": CategoricalActionSpace(["0", "1"])}
 
     def reset_filter(self, obs_space: ObsSpace) -> Observation:
@@ -51,7 +49,7 @@ class Xor(Environment):
         return self.observe(obs_space)
 
     def reset(self) -> Observation:
-        return self.reset_filter(Xor.obs_space())
+        return self.reset_filter(self.obs_space())
 
     def act_filter(
         self, action: Mapping[str, Action], obs_filter: ObsSpace
@@ -70,7 +68,7 @@ class Xor(Environment):
     def act(self, action: Mapping[str, Action]) -> Observation:
         return self.act_filter(
             action,
-            Xor.obs_space(),
+            self.obs_space(),
         )
 
     def observe(

--- a/entity_gym/entity_gym/main.py
+++ b/entity_gym/entity_gym/main.py
@@ -43,8 +43,8 @@ if __name__ == "__main__":
 
     print(env_cls)
     env = env_cls()
-    obs_space = env_cls.obs_space()
-    actions = env_cls.action_space()
+    obs_space = env.obs_space()
+    actions = env.action_space()
     obs = env.reset_filter(obs_space)
     total_reward = obs.reward
     while not obs.done:

--- a/entity_gym/entity_gym/serialization/sample_recorder.py
+++ b/entity_gym/entity_gym/serialization/sample_recorder.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Type
-from entity_gym.environment.environment import ActionType
+from typing import Any, Dict, List, Mapping, Optional
 
 import msgpack_numpy
 import numpy as np
 from ragged_buffer import RaggedBufferF32, RaggedBufferI64
 
-from entity_gym.environment import ActionSpace, Environment, ObsSpace, VecEnv, VecObs
+from entity_gym.environment import ActionSpace, ObsSpace, VecEnv, VecObs
+from entity_gym.environment.environment import ActionType
 from entity_gym.serialization.msgpack_ragged import (
     ragged_buffer_decode,
     ragged_buffer_encode,

--- a/entity_gym/entity_gym/serialization/sample_recorder.py
+++ b/entity_gym/entity_gym/serialization/sample_recorder.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Type
+from entity_gym.environment.environment import ActionType
 
 import msgpack_numpy
 import numpy as np
@@ -97,8 +98,8 @@ class SampleRecordingVecEnv(VecEnv):
         self.subsample = subsample
         self.sample_recorder = SampleRecorder(
             out_path,
-            inner.env_cls().action_space(),
-            inner.env_cls().obs_space(),
+            inner.action_space(),
+            inner.obs_space(),
             subsample,
         )
         self.last_obs: Optional[VecObs] = None
@@ -180,8 +181,11 @@ class SampleRecordingVecEnv(VecEnv):
     def render(self, **kwargs: Any) -> np.ndarray:
         return self.inner.render(**kwargs)
 
-    def env_cls(cls) -> Type[Environment]:
-        return super().env_cls()
+    def action_space(self) -> Dict[ActionType, ActionSpace]:
+        return self.inner.action_space()
+
+    def obs_space(self) -> ObsSpace:
+        return self.inner.obs_space()
 
     def __len__(self) -> int:
         return len(self.inner)

--- a/entity_gym/entity_gym/tests/test_environment.py
+++ b/entity_gym/entity_gym/tests/test_environment.py
@@ -24,12 +24,9 @@ from entity_gym.examples.xor import Xor
 
 
 def test_env_list() -> None:
-    env_cls = CherryPick
-
-    obs_space = env_cls.obs_space()
-
     # 100 environments
-    envs = EnvList(env_cls, {}, 100)
+    envs = EnvList(CherryPick, {}, 100)
+    obs_space = envs.obs_space()
 
     obs_reset = envs.reset(obs_space)
     assert len(obs_reset.done) == 100
@@ -43,12 +40,9 @@ def test_env_list() -> None:
 
 
 def test_parallel_env_list() -> None:
-    env_cls = CherryPick
-
-    obs_space = env_cls.obs_space()
-
     # 100 environments split across 10 processes
-    envs = ParallelEnvList(env_cls, {}, 100, 10)
+    envs = ParallelEnvList(CherryPick, {}, 100, 10)
+    obs_space = envs.obs_space()
 
     obs_reset = envs.reset(obs_space)
     assert len(obs_reset.done) == 100
@@ -60,12 +54,12 @@ def test_parallel_env_list() -> None:
     assert len(obs_act.done) == 100
 
     envs = ParallelEnvList(Xor, {}, 100, 10)
-    obs_reset = envs.reset(Xor.obs_space())
+    obs_reset = envs.reset(envs.obs_space())
     assert len(obs_reset.done) == 100
     actions_xor = {
         "output": RaggedBufferI64.from_array(np.zeros((100, 1, 1), np.int64))
     }
-    obs_act = envs.act(actions_xor, Xor.obs_space())
+    obs_act = envs.act(actions_xor, envs.obs_space())
     assert len(obs_act.done) == 100
 
 


### PR DESCRIPTION
Changes `Environment.obs_space` and `Environment.action_space` from class to instance methods. Also removes the `env_cls` method on `VecEnv` in favor of `obs_space` and `action_space` methods. This makes it much easier to create environment wrappers, environments where the action/observation space depend on configuration, and `VecEnv` implementations which don't have an underlying `Environment` class.